### PR TITLE
Fix: openai package pinning and tests 

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+TINFOIL_API_KEY=tk_1nZF1s1duwff6zpIjpGRKiaf5o2P9UBJMurUxaB9THVpveud

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MacPaw/OpenAI.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "bf9aa18029cd22d39dad3e1f00dd40a5a4777f57"
+        "revision" : "bb283b2ac48c1e90121d73d6bfb45f961dc0b7a3",
+        "version" : "0.4.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/MacPaw/OpenAI.git", branch: "main"),
+        .package(url: "https://github.com/MacPaw/OpenAI.git", exact: "0.4.5"),
     ],
     targets: [
         .binaryTarget(
@@ -26,7 +26,10 @@ let package = Package(
                 .product(name: "OpenAI", package: "OpenAI"),
                 "TinfoilVerifier"
             ],
-            path: "Sources/TinfoilAI"),
+            path: "Sources/TinfoilAI",
+            linkerSettings: [
+                .linkedLibrary("resolv")
+            ]),
         .testTarget(
             name: "TinfoilAITests",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "TinfoilVerifier",
-            url: "https://github.com/tinfoilsh/verifier/releases/download/v0.2.2/TinfoilVerifier.xcframework.zip",
-            checksum: "2bbddac259a4a2cbb631db38496923ac0b544da215326660437b5716783fa0b8"),
+            url: "https://github.com/tinfoilsh/verifier/releases/download/v0.2.3/TinfoilVerifier.xcframework.zip",
+            checksum: "206fb8de5bf342a2fd27bfc9893b5907b92c1d52f3e0f9ccb0346fa736679633"),
         .target(
             name: "TinfoilAI",
             dependencies: [

--- a/Sources/TinfoilAI/TinfoilClient.swift
+++ b/Sources/TinfoilAI/TinfoilClient.swift
@@ -34,7 +34,7 @@ public class TinfoilClient {
     
     public static func create(
         apiKey: String,
-        enclaveURL: String,
+        enclaveURL: String = TinfoilConstants.defaultEnclaveURL,
         expectedFingerprint: String,
         parsingOptions: ParsingOptions = .relaxed,
         nonblockingVerification: NonblockingVerification? = nil

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -93,8 +93,8 @@ public class SecureClient {
     ///   - enclaveURL: URL for the enclave attestation endpoint
     ///   - callbacks: Optional callbacks for verification progress
     public init(
-        githubRepo: String,
-        enclaveURL: String,
+        githubRepo: String = TinfoilConstants.defaultGithubRepo,
+        enclaveURL: String = TinfoilConstants.defaultEnclaveURL,
         callbacks: VerificationCallbacks = VerificationCallbacks()
     ) {
         self.githubRepo = githubRepo
@@ -123,9 +123,9 @@ public class SecureClient {
                 throw error
             }
             
-            // Run verification - this returns the GroundTruth object from Go
+            // Run verification
             do {
-                let groundTruthResult = try client.verify()
+                _ = try client.verify()
             } catch {
                 let verificationError = VerificationError.verificationFailed("Verification failed: \(error.localizedDescription)")
                 callbacks.onVerificationComplete(.failure(verificationError))

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -8,7 +8,6 @@ final class TinfoilAITests: XCTestCase {
         
 
     func testClientSucceedsWhenVerificationSucceeds() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Create client using defaults - this will perform verification internally
         let client = try await TinfoilAI.create(apiKey: apiKey)
@@ -18,7 +17,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("Say 'Hello' and nothing else.")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         let response = try await client.chats(query: chatQuery)
@@ -29,7 +28,6 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testCertificatePinningSuccess() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Get the correct fingerprint from verification using defaults
         let secureClient = SecureClient()
@@ -49,7 +47,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("Say 'Success' and nothing else.")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         let response = try await tinfoilClient.underlyingClient.chats(query: chatQuery)
@@ -60,7 +58,6 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testCertificatePinningFailure() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Create client with wrong fingerprint
         let wrongFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -75,7 +72,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("This should fail")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         do {
@@ -93,7 +90,6 @@ final class TinfoilAITests: XCTestCase {
     // MARK: - Streaming Tests
     
     func testStreamingChatCompletion() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Create client using defaults - this will perform verification internally
         let client = try await TinfoilAI.create(apiKey: apiKey)
@@ -103,7 +99,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("Count from 1 to 5, one number per response.")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         var receivedChunks: [ChatStreamResult] = []
@@ -131,7 +127,6 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testStreamingWithCertificatePinning() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Get the correct fingerprint from verification using defaults
         let secureClient = SecureClient()
@@ -151,7 +146,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("Say 'Streaming works!' and nothing else.")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         var receivedChunks: [ChatStreamResult] = []
@@ -168,7 +163,6 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testStreamingFailsWithWrongCertificate() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Create client with wrong fingerprint
         let wrongFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -183,7 +177,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("This streaming should fail")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         do {
@@ -201,7 +195,6 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testStreamingResponseStructure() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Create TinfoilAI client using defaults
         let client = try await TinfoilAI.create(apiKey: apiKey)
@@ -211,7 +204,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("Say 'Test' exactly once.")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         var hasId = false
@@ -249,7 +242,6 @@ final class TinfoilAITests: XCTestCase {
     // MARK: - Non-blocking Verification Tests
     
     func testNonblockingVerificationWithCorrectFingerprint() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Set up verification callback expectation
         class VerificationResultWrapper {
@@ -274,7 +266,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("Say 'Success' and nothing else.")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         let response = try await client.chats(query: chatQuery)
@@ -289,7 +281,6 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testNonblockingVerificationWithIncorrectFingerprint() async throws {
-        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
         
         // Set up verification callback expectation  
         class VerificationResultWrapper {
@@ -317,7 +308,7 @@ final class TinfoilAITests: XCTestCase {
             messages: [
                 .user(.init(content: .string("This should succeed in non-blocking mode")))
             ],
-            model: "llama3-3-70b"
+            model: "llama-free"
         )
         
         let response = try await tinfoilClient.underlyingClient.chats(query: chatQuery)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Pinned the OpenAI client to v0.4.5 and bumped TinfoilVerifier to v0.2.3 to stabilize builds. Added sensible defaults for the enclave URL and GitHub repo, and switched tests to the free model.

- **Dependencies**
  - Pin MacPaw/OpenAI to 0.4.5.
  - Update TinfoilVerifier binary to v0.2.3 (new checksum).
  - Link libresolv in TinfoilAI target.

- **Bug Fixes**
  - Default enclaveURL and githubRepo in TinfoilClient and SecureClient.
  - Use "llama-free" in tests and stop per-test env reads; add .env with TINFOIL_API_KEY for local runs.

<!-- End of auto-generated description by cubic. -->

