### PR TITLE
Feat: support new EHBP protocol format 

### DIFF
--- a/Sources/TinfoilAI/Constants.swift
+++ b/Sources/TinfoilAI/Constants.swift
@@ -7,4 +7,4 @@ public enum TinfoilConstants {
     
     /// Default GitHub repository for the inference proxy
     public static let defaultGithubRepo = "tinfoilsh/confidential-inference-proxy"
-} 
+}

--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -40,7 +40,7 @@ public enum TinfoilAI {
         let tinfoilClient = try TinfoilClient.create(
             apiKey: finalApiKey,
             enclaveURL: enclaveURL,
-            expectedFingerprint: groundTruth.publicKeyFP,
+            expectedFingerprint: groundTruth.tlsPublicKey,
             parsingOptions: parsingOptions,
             nonblockingVerification: nonblockingVerification
         )

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -65,14 +65,16 @@ public struct Measurement: Codable {
 
 /// Ground truth structure matching Go's client.GroundTruth
 public struct GroundTruth: Codable {
-    public let publicKeyFP: String
+    public let tlsPublicKey: String
+    public let hpkePublicKey: String
     public let digest: String
     public let codeMeasurement: Measurement?
     public let enclaveMeasurement: Measurement?
     public let hardwarePlatform: String?
     
     private enum CodingKeys: String, CodingKey {
-        case publicKeyFP = "public_key"
+        case tlsPublicKey = "tls_public_key"
+        case hpkePublicKey = "hpke_public_key"
         case digest
         case codeMeasurement = "code_measurement"
         case enclaveMeasurement = "enclave_measurement"
@@ -135,13 +137,13 @@ public class SecureClient {
             // Get the ground truth as JSON string from the client
             var jsonError: NSError?
             let jsonString = client.groundTruthJSON(&jsonError)
-            
+
             if let error = jsonError {
                 let verificationError = VerificationError.jsonDecodingFailed(error.localizedDescription)
                 callbacks.onVerificationComplete(.failure(verificationError))
                 throw verificationError
             }
-            
+
             guard let jsonData = jsonString.data(using: .utf8) else {
                 let verificationError = VerificationError.jsonDecodingFailed("Failed to convert JSON string to data")
                 callbacks.onVerificationComplete(.failure(verificationError))

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -10,7 +10,7 @@ final class TinfoilAITests: XCTestCase {
     func testClientSucceedsWhenVerificationSucceeds() async throws {
         
         // Create client using defaults - this will perform verification internally
-        let client = try await TinfoilAI.create(apiKey: apiKey)
+        let client = try await TinfoilAI.create(apiKey: "tinfoil")
         
         // Test that client can make a successful request
         let chatQuery = ChatQuery(
@@ -33,11 +33,11 @@ final class TinfoilAITests: XCTestCase {
         let secureClient = SecureClient()
         
         let verificationResult = try await secureClient.verify()
-        let expectedFingerprint = verificationResult.publicKeyFP
+        let expectedFingerprint = verificationResult.tlsPublicKey
         
         // Create client with correct fingerprint and relaxed parsing
         let tinfoilClient = try TinfoilClient.create(
-            apiKey: apiKey,
+            apiKey: "tinfoil",
             expectedFingerprint: expectedFingerprint,
             parsingOptions: .relaxed
         )
@@ -63,7 +63,7 @@ final class TinfoilAITests: XCTestCase {
         let wrongFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
         
         let tinfoilClient = try TinfoilClient.create(
-            apiKey: apiKey,
+            apiKey: "tinfoil",
             expectedFingerprint: wrongFingerprint
         )
         
@@ -92,7 +92,7 @@ final class TinfoilAITests: XCTestCase {
     func testStreamingChatCompletion() async throws {
         
         // Create client using defaults - this will perform verification internally
-        let client = try await TinfoilAI.create(apiKey: apiKey)
+        let client = try await TinfoilAI.create(apiKey: "tinfoil")
         
         // Test streaming chat completion
         let chatQuery = ChatQuery(
@@ -132,11 +132,11 @@ final class TinfoilAITests: XCTestCase {
         let secureClient = SecureClient()
         
         let verificationResult = try await secureClient.verify()
-        let expectedFingerprint = verificationResult.publicKeyFP
+        let expectedFingerprint = verificationResult.tlsPublicKey
         
         // Create client with correct fingerprint and relaxed parsing
         let tinfoilClient = try TinfoilClient.create(
-            apiKey: apiKey,
+            apiKey: "tinfoil",
             expectedFingerprint: expectedFingerprint,
             parsingOptions: .relaxed
         )
@@ -168,7 +168,7 @@ final class TinfoilAITests: XCTestCase {
         let wrongFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
         
         let tinfoilClient = try TinfoilClient.create(
-            apiKey: apiKey,
+            apiKey: "tinfoil",
             expectedFingerprint: wrongFingerprint
         )
         
@@ -197,7 +197,7 @@ final class TinfoilAITests: XCTestCase {
     func testStreamingResponseStructure() async throws {
         
         // Create TinfoilAI client using defaults
-        let client = try await TinfoilAI.create(apiKey: apiKey)
+        let client = try await TinfoilAI.create(apiKey: "tinfoil")
         
         // Test streaming response structure
         let chatQuery = ChatQuery(
@@ -257,7 +257,7 @@ final class TinfoilAITests: XCTestCase {
         
         // Create TinfoilAI client with non-blocking verification using defaults
         let client = try await TinfoilAI.create(
-            apiKey: apiKey,
+            apiKey: "tinfoil",
             nonblockingVerification: nonblockingCallback
         )
         
@@ -298,7 +298,7 @@ final class TinfoilAITests: XCTestCase {
         let wrongFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
         
         let tinfoilClient = try TinfoilClient.create(
-            apiKey: apiKey,
+            apiKey: "tinfoil",
             expectedFingerprint: wrongFingerprint,
             nonblockingVerification: nonblockingCallback
         )


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add support for the new EHBP ground-truth format by switching to TLS and HPKE public keys. Verification now uses tls_public_key for the expected fingerprint.

- **New Features**
  - Parse tls_public_key and hpke_public_key in GroundTruth.
  - Use tls_public_key for TinfoilClient expectedFingerprint.
  - Tests updated to reflect the new fields and remove real API key usage.

- **Migration**
  - GroundTruth.publicKeyFP renamed to tlsPublicKey.
  - JSON keys changed: public_key -> tls_public_key; added hpke_public_key.
  - Update any code that reads GroundTruth or expects the old JSON shape.

<!-- End of auto-generated description by cubic. -->

