### PR TITLE
Chore: update verifier 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "TinfoilVerifier",
-            url: "https://github.com/tinfoilsh/verifier/releases/download/v0.2.3/TinfoilVerifier.xcframework.zip",
-            checksum: "206fb8de5bf342a2fd27bfc9893b5907b92c1d52f3e0f9ccb0346fa736679633"),
+            url: "https://github.com/tinfoilsh/verifier/releases/download/v0.10.1/TinfoilVerifier.xcframework.zip",
+            checksum: "7fc9008f8bc1a0afddd35918b5998163fc5763ac8aaaccd4ad619aa315bd7778"),
         .target(
             name: "TinfoilAI",
             dependencies: [

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -66,7 +66,7 @@ public struct Measurement: Codable {
 /// Ground truth structure matching Go's client.GroundTruth
 public struct GroundTruth: Codable {
     public let tlsPublicKey: String
-    public let hpkePublicKey: String
+    public let hpkePublicKey: String?
     public let digest: String
     public let codeMeasurement: Measurement?
     public let enclaveMeasurement: Measurement?


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updates the TinfoilVerifier binary to v0.10.1 and makes GroundTruth.hpkePublicKey optional to keep older attestations working.

- **Dependencies**
  - Bump TinfoilVerifier to v0.10.1 (updated URL and checksum).

- **Bug Fixes**
  - Make hpkePublicKey optional to prevent decode failures when the field is missing.

<!-- End of auto-generated description by cubic. -->

