### PR TITLE
chore: update swift openai client

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MacPaw/OpenAI.git",
       "state" : {
-        "revision" : "bb283b2ac48c1e90121d73d6bfb45f961dc0b7a3",
-        "version" : "0.4.5"
+        "branch" : "main",
+        "revision" : "c8b02fc5e3ec1df6925158b52c64959408f86b84"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/MacPaw/OpenAI.git", exact: "0.4.5"),
+        .package(url: "https://github.com/MacPaw/OpenAI.git", branch: "main"),
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched the MacPaw/OpenAI Swift client from pinned 0.4.5 to the main branch to pick up recent fixes and changes. Updated Package.swift and Package.resolved accordingly.

<!-- End of auto-generated description by cubic. -->

