### PR TITLE
feat: implement router select logic

### DIFF
--- a/Sources/TinfoilAI/Constants.swift
+++ b/Sources/TinfoilAI/Constants.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Default configuration constants for Tinfoil
 public enum TinfoilConstants {
-    /// Default Tinfoil proxy enclave URL
-    public static let defaultEnclaveURL = "inference.tinfoil.sh"
-    
     /// Default GitHub repository for the inference proxy
-    public static let defaultGithubRepo = "tinfoilsh/confidential-inference-proxy"
+    public static let defaultGithubRepo = "tinfoilsh/confidential-model-router"
+
+    /// ATC (Attestation and Trust Center) API URL for fetching available routers
+    public static let atcAPIURL = "https://atc.tinfoil.sh/routers"
 }

--- a/Sources/TinfoilAI/RouterManager.swift
+++ b/Sources/TinfoilAI/RouterManager.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Router management utilities for fetching available Tinfoil routers
+public enum RouterManager {
+
+    /// Error types for router fetching operations
+    public enum RouterError: Error, LocalizedError {
+        case networkError(String)
+        case invalidResponse
+        case noRoutersFound
+
+        public var errorDescription: String? {
+            switch self {
+            case .networkError(let message):
+                return "Failed to fetch routers: \(message)"
+            case .invalidResponse:
+                return "Invalid response format from router API"
+            case .noRoutersFound:
+                return "No routers found in the response"
+            }
+        }
+    }
+
+    /// Selects a random router from the provided list
+    /// - Parameter routers: Array of router addresses
+    /// - Returns: A randomly selected router address
+    /// - Throws: RouterError.noRoutersFound if the array is empty
+    internal static func selectRouter(from routers: [String]) throws -> String {
+        guard !routers.isEmpty else {
+            throw RouterError.noRoutersFound
+        }
+        let randomIndex = Int.random(in: 0..<routers.count)
+        return routers[randomIndex]
+    }
+
+    /// Fetches the list of available routers from the ATC API
+    /// and returns a randomly selected address.
+    ///
+    /// - Returns: A randomly selected router address
+    /// - Throws: RouterError if no routers are found or if the request fails
+    public static func fetchRouter() async throws -> String {
+        let routersURL = TinfoilConstants.atcAPIURL
+
+        guard let url = URL(string: routersURL) else {
+            throw RouterError.networkError("Invalid URL: \(routersURL)")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw RouterError.networkError("Invalid response type")
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                throw RouterError.networkError("\(httpResponse.statusCode) \(HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode))")
+            }
+
+            // Try to decode the response
+            let routers: [String]
+            do {
+                routers = try JSONDecoder().decode([String].self, from: data)
+            } catch {
+                // Decoding failed - invalid response format
+                throw RouterError.invalidResponse
+            }
+
+            // Select and return a random router
+            return try selectRouter(from: routers)
+
+        } catch let error as RouterError {
+            throw error
+        } catch {
+            throw RouterError.networkError(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/TinfoilAI/TinfoilClient.swift
+++ b/Sources/TinfoilAI/TinfoilClient.swift
@@ -34,25 +34,28 @@ public class TinfoilClient {
     
     public static func create(
         apiKey: String,
-        enclaveURL: String = TinfoilConstants.defaultEnclaveURL,
+        enclaveURL: String,
         expectedFingerprint: String,
         parsingOptions: ParsingOptions = .relaxed,
         nonblockingVerification: NonblockingVerification? = nil
     ) throws -> TinfoilClient {
+        // Use provided URL
+        let finalEnclaveURL = enclaveURL
+
         // Create the secure URLSession with certificate pinning and extraction
         let urlSession = SecureURLSessionFactory.createSession(
             expectedFingerprint: expectedFingerprint,
             nonblockingVerification: nonblockingVerification
         )
-        
+
         // Create SSL delegate for streaming certificate pinning
         let sslDelegate = StreamingSSLDelegate(
             expectedFingerprint: expectedFingerprint,
             nonblockingVerification: nonblockingVerification
         )
-        
+
         // Parse the enclave URL
-        let urlComponents = try URLHelpers.parseURL(enclaveURL)
+        let urlComponents = try URLHelpers.parseURL(finalEnclaveURL)
         
         // Build host string with port if needed
         let hostWithPort = URLHelpers.buildHostWithPort(host: urlComponents.host, port: urlComponents.port)

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -96,7 +96,7 @@ public class SecureClient {
     ///   - callbacks: Optional callbacks for verification progress
     public init(
         githubRepo: String = TinfoilConstants.defaultGithubRepo,
-        enclaveURL: String = TinfoilConstants.defaultEnclaveURL,
+        enclaveURL: String,
         callbacks: VerificationCallbacks = VerificationCallbacks()
     ) {
         self.githubRepo = githubRepo

--- a/Tests/RouterManagerTests.swift
+++ b/Tests/RouterManagerTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import TinfoilAI
+
+final class RouterManagerTests: XCTestCase {
+
+    func testATCAPIURLIsValid() {
+        // Test that the ATC API URL is valid
+        XCTAssertNotNil(URL(string: TinfoilConstants.atcAPIURL))
+        XCTAssertEqual(TinfoilConstants.atcAPIURL, "https://atc.tinfoil.sh/routers")
+    }
+
+    func testRouterErrorDescriptions() {
+        let networkError = RouterManager.RouterError.networkError("Connection failed")
+        XCTAssertEqual(networkError.errorDescription, "Failed to fetch routers: Connection failed")
+
+        let invalidResponse = RouterManager.RouterError.invalidResponse
+        XCTAssertEqual(invalidResponse.errorDescription, "Invalid response format from router API")
+
+        let noRouters = RouterManager.RouterError.noRoutersFound
+        XCTAssertEqual(noRouters.errorDescription, "No routers found in the response")
+    }
+
+    func testErrorHandlingDistinction() {
+        // This test verifies that the error types are distinct and properly categorized
+        // Testing that invalidResponse is different from noRoutersFound
+        let invalidResponseError = RouterManager.RouterError.invalidResponse
+        let noRoutersError = RouterManager.RouterError.noRoutersFound
+
+        // Ensure they have different descriptions
+        XCTAssertNotEqual(invalidResponseError.errorDescription, noRoutersError.errorDescription)
+
+        // Test the error cases are distinct
+        switch invalidResponseError {
+        case .invalidResponse:
+            XCTAssertTrue(true, "Should be invalidResponse")
+        default:
+            XCTFail("Wrong error type")
+        }
+
+        switch noRoutersError {
+        case .noRoutersFound:
+            XCTAssertTrue(true, "Should be noRoutersFound")
+        default:
+            XCTFail("Wrong error type")
+        }
+    }
+
+    func testSelectRouterFromList() throws {
+        // Test that selectRouter works with valid input
+        let routers = ["router1.example.com", "router2.example.com", "router3.example.com"]
+
+        // Test that selection returns one of the provided routers
+        let selected = try RouterManager.selectRouter(from: routers)
+        XCTAssertTrue(routers.contains(selected), "Selected router should be from the provided list")
+    }
+
+    func testSelectRouterFromEmptyList() {
+        // Test that selectRouter throws correct error for empty array
+        let emptyRouters: [String] = []
+
+        XCTAssertThrowsError(try RouterManager.selectRouter(from: emptyRouters)) { error in
+            guard let routerError = error as? RouterManager.RouterError else {
+                XCTFail("Expected RouterError but got \(error)")
+                return
+            }
+
+            if case .noRoutersFound = routerError {
+                // Expected error
+            } else {
+                XCTFail("Expected noRoutersFound error but got \(routerError)")
+            }
+        }
+    }
+
+    func testSelectRouterRandomness() throws {
+        // Test that selection has some randomness (statistical test)
+        let routers = ["router1", "router2", "router3"]
+        var selections = Set<String>()
+
+        // Run multiple selections to verify randomness
+        for _ in 0..<100 {
+            let selected = try RouterManager.selectRouter(from: routers)
+            selections.insert(selected)
+        }
+
+        // With 100 iterations and 3 routers, we expect to see at least 2 different selections
+        // The probability of selecting the same router 100 times is (1/3)^100 ≈ 0
+        XCTAssertGreaterThanOrEqual(selections.count, 2, "Router selection should show randomness")
+    }
+}

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -29,8 +29,8 @@ final class TinfoilAITests: XCTestCase {
     
     func testCertificatePinningSuccess() async throws {
         
-        // Get the correct fingerprint from verification using defaults
-        let secureClient = SecureClient()
+        // Get the correct fingerprint from verification using a valid router URL
+        let secureClient = SecureClient(enclaveURL: "router.inf6.tinfoil.sh")
         
         let verificationResult = try await secureClient.verify()
         let expectedFingerprint = verificationResult.tlsPublicKey
@@ -38,6 +38,7 @@ final class TinfoilAITests: XCTestCase {
         // Create client with correct fingerprint and relaxed parsing
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
+            enclaveURL: "router.inf6.tinfoil.sh",
             expectedFingerprint: expectedFingerprint,
             parsingOptions: .relaxed
         )
@@ -64,6 +65,7 @@ final class TinfoilAITests: XCTestCase {
         
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
+            enclaveURL: "router.inf6.tinfoil.sh",
             expectedFingerprint: wrongFingerprint
         )
         
@@ -128,8 +130,8 @@ final class TinfoilAITests: XCTestCase {
     
     func testStreamingWithCertificatePinning() async throws {
         
-        // Get the correct fingerprint from verification using defaults
-        let secureClient = SecureClient()
+        // Get the correct fingerprint from verification using a valid router URL
+        let secureClient = SecureClient(enclaveURL: "router.inf6.tinfoil.sh")
         
         let verificationResult = try await secureClient.verify()
         let expectedFingerprint = verificationResult.tlsPublicKey
@@ -137,6 +139,7 @@ final class TinfoilAITests: XCTestCase {
         // Create client with correct fingerprint and relaxed parsing
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
+            enclaveURL: "router.inf6.tinfoil.sh",
             expectedFingerprint: expectedFingerprint,
             parsingOptions: .relaxed
         )
@@ -169,6 +172,7 @@ final class TinfoilAITests: XCTestCase {
         
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
+            enclaveURL: "router.inf6.tinfoil.sh",
             expectedFingerprint: wrongFingerprint
         )
         
@@ -299,6 +303,7 @@ final class TinfoilAITests: XCTestCase {
         
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
+            enclaveURL: "router.inf6.tinfoil.sh",
             expectedFingerprint: wrongFingerprint,
             nonblockingVerification: nonblockingCallback
         )

--- a/Tests/TinfoilIntegrationTests.swift
+++ b/Tests/TinfoilIntegrationTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import TinfoilAI
+import OpenAI
+
+final class TinfoilIntegrationTests: XCTestCase {
+
+    func testCreateWithExplicitEnclaveURL() async throws {
+        // Test that when an explicit enclave URL is provided, it's used directly
+        // This test validates the behavior without making actual network calls
+
+        let explicitURL = "custom.enclave.example.com"
+
+        // We can't directly test the full flow without mocking the verification,
+        // but we can test that the URL parameter is properly handled
+        do {
+            _ = try await TinfoilAI.create(
+                apiKey: "test-key",
+                enclaveURL: explicitURL
+            )
+        } catch {
+            // Expected to fail during verification, but that's OK for this test
+            // We're just testing that the explicit URL would be used
+            if let tinfoilError = error as? TinfoilError {
+                XCTAssertNotEqual(tinfoilError, TinfoilError.missingAPIKey)
+            }
+        }
+    }
+
+    func testCreateWithoutEnclaveURLUsesRouter() async throws {
+        // Test that when no enclave URL is provided, router fetching is triggered
+        // This test validates the behavior without making actual network calls
+
+        do {
+            _ = try await TinfoilAI.create(
+                apiKey: "test-key"
+                // No enclaveURL provided - should trigger router fetch
+            )
+        } catch {
+            // Expected to fail (either during router fetch or verification)
+            // We're validating that the router fetch path is triggered
+            if let tinfoilError = error as? TinfoilError {
+                XCTAssertNotEqual(tinfoilError, TinfoilError.missingAPIKey)
+            }
+        }
+    }
+
+    func testMissingAPIKeyError() async throws {
+        // Test that missing API key throws the correct error
+        do {
+            _ = try await TinfoilAI.create(
+                apiKey: nil,
+                enclaveURL: "test.example.com"
+            )
+            XCTFail("Should have thrown missingAPIKey error")
+        } catch TinfoilError.missingAPIKey {
+            // Expected error
+            XCTAssertTrue(true)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testTinfoilClientWithExplicitURL() throws {
+        // Test TinfoilClient.create with explicit URL parameter
+        do {
+            _ = try TinfoilClient.create(
+                apiKey: "test-key",
+                enclaveURL: "test.example.com",
+                expectedFingerprint: "test-fingerprint"
+            )
+        } catch {
+            // Expected to fail during URL parsing or connection
+            // We're just testing that explicit URL is handled
+            XCTAssertNotNil(error)
+        }
+
+        // Test with explicit URL
+        do {
+            _ = try TinfoilClient.create(
+                apiKey: "test-key",
+                enclaveURL: "custom.example.com",
+                expectedFingerprint: "test-fingerprint"
+            )
+        } catch {
+            // Expected to fail during URL parsing or connection
+            // We're just testing that explicit URL is handled
+            XCTAssertNotNil(error)
+        }
+    }
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds automatic router selection via ATC when no enclave URL is provided, making setup simpler and more resilient. Also updates defaults to the model router repo and threads the enclave URL explicitly through verification and client creation.

- **New Features**
  - Added RouterManager.fetchRouter() to fetch from https://atc.tinfoil.sh/routers and pick a random router.
  - TinfoilAI.create uses the router when enclaveURL is nil; explicit URLs still work.
  - Updated default GitHub repo to tinfoilsh/confidential-model-router; added TinfoilConstants.atcAPIURL.
  - Introduced RouterManager.RouterError; made TinfoilError Equatable.
  - Added tests for router selection and explicit URL flows.

- **Migration**
  - Remove uses of TinfoilConstants.defaultEnclaveURL.
  - Pass enclaveURL to SecureClient(...) and TinfoilClient.create(...), or omit enclaveURL in TinfoilAI.create to auto-select via the router.

<!-- End of auto-generated description by cubic. -->

