### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Automates GitHub releases when pushing tags like v1.2.3. Runs on macOS with latest-stable Xcode and publishes a release with generated notes.

- **New Features**
  - Adds .github/workflows/release.yml
  - Triggers on push tags matching v*
  - Checks out full history (fetch-depth: 0)
  - Creates a GitHub Release using softprops/action-gh-release with release notes enabled

<!-- End of auto-generated description by cubic. -->

