### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Swift](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20|%20macOS-blue.svg)](https://developer.apple.com)
 [![Tests](https://github.com/tinfoilsh/tinfoil-swift/actions/workflows/test.yml/badge.svg)](https://github.com/tinfoilsh/tinfoil-swift/actions/workflows/test.yml)
+[![Docs](https://img.shields.io/badge/Docs-Swift%20SDK-blue.svg)](https://docs.tinfoil.sh/sdk/swift-sdk)
 
 A secure Swift SDK for communicating with AI models running in Tinfoil's confidential computing enclaves. This SDK wraps the [MacPaw OpenAI SDK](https://github.com/MacPaw/OpenAI) with additional security features including automatic enclave verification, certificate pinning, and attestation validation.
 

--- a/README.md
+++ b/README.md
@@ -118,21 +118,25 @@ let client = try await TinfoilAI.create(
 let client = try await TinfoilAI.create(
     apiKey: String? = nil,              // API key (uses TINFOIL_API_KEY env var if nil)
     enclaveURL: String? = nil,           // Custom enclave URL (auto-selects router if nil)
-    githubRepo: String = "example/repo", // GitHub repo for verification (uses default if not provided)
+    githubRepo: String = "org/repo", // GitHub repo for verification (default: "tinfoilsh/confidential-model-router")
     parsingOptions: ParsingOptions = .relaxed,  // OpenAI parsing options
     onVerification: ((VerificationDocument?) -> Void)? = nil // Verification callback
 )
 
-// Returns: OpenAI  // The configured OpenAI client
+// Returns: OpenAI - The configured OpenAI client
 ```
 
 ## API Documentation
 
-This library is a secure wrapper around the [MacPaw OpenAI SDK](https://github.com/MacPaw/OpenAI) that can be used with Tinfoil. The `TinfoilAI.create()` method returns an OpenAI client configured for secure communication with Tinfoil enclaves. See the [MacPaw OpenAI SDK documentation](https://github.com/MacPaw/OpenAI) for complete API usage and documentation.
+This library is a secure wrapper around the [MacPaw OpenAI SDK](https://github.com/MacPaw/OpenAI) that can be used with Tinfoil. The `TinfoilAI.create()` method returns an OpenAI client configured for secure communication with Tinfoil enclaves.
+
+For complete documentation, see:
+- [Swift SDK Documentation](https://docs.tinfoil.sh/sdk/swift-sdk)
+- [MacPaw OpenAI SDK Documentation](https://github.com/MacPaw/OpenAI)
 
 ## Requirements
 
-- iOS 15.0+ / macOS 12.0+
+- iOS 17.0+ / macOS 12.0+
 - Swift 5.9+
 - Xcode 15.0+
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated README to clarify the githubRepo default, add official docs links, and raise the stated iOS minimum to 17+. Improves setup guidance and makes defaults explicit.

- **Migration**
  - If your app targets iOS < 17, update your deployment target or stick with a previous compatible version.

<sup>Written for commit a6f13e0cbbdd58a65ac37b24da735b680676dd55. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



