### PR TITLE
Feat: update tests and verifier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "TinfoilVerifier",
-            url: "https://github.com/tinfoilsh/verifier/releases/download/v0.10.4/TinfoilVerifier.xcframework.zip",
-            checksum: "fad3a6236c796d5411798f21dfb9c4940e871a6cc6a285e9a4aad869bdf60f3d"),
+            url: "https://github.com/tinfoilsh/verifier/releases/download/v0.10.16/TinfoilVerifier.xcframework.zip",
+            checksum: "3bfa31626f83851c4c16ccfb75312197b6a3e1482d56f20c06b551e5375c2432"),
         .target(
             name: "TinfoilAI",
             dependencies: [

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -137,8 +137,7 @@ public class SecureClient {
         let jsonString: String
         do {
             var error: NSError?
-            // Pass nil for sigstoreTrustedRootJSON parameter (uses default trusted root)
-            jsonString = TinfoilVerifier.ClientVerifyJSON(nil, urlComponents.host, githubRepo, &error)
+            jsonString = TinfoilVerifier.ClientVerifyJSON(urlComponents.host, githubRepo, nil, &error)
 
             if let error = error {
                 throw error

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -137,7 +137,8 @@ public class SecureClient {
         let jsonString: String
         do {
             var error: NSError?
-            jsonString = TinfoilVerifier.ClientVerifyJSON(urlComponents.host, githubRepo, &error)
+            // Pass nil for sigstoreTrustedRootJSON parameter (uses default trusted root)
+            jsonString = TinfoilVerifier.ClientVerifyJSON(nil, urlComponents.host, githubRepo, &error)
 
             if let error = error {
                 throw error

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -28,17 +28,18 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testCertificatePinningSuccess() async throws {
-        
-        // Get the correct fingerprint from verification using a valid router URL
-        let secureClient = SecureClient(enclaveURL: "router.inf6.tinfoil.sh")
-        
+
+        let routerAddress = try await RouterManager.fetchRouter()
+        let enclaveURL = "https://\(routerAddress)"
+
+        let secureClient = SecureClient(enclaveURL: enclaveURL)
+
         let verificationResult = try await secureClient.verify()
         let expectedFingerprint = verificationResult.tlsPublicKey
-        
-        // Create client with correct fingerprint and relaxed parsing
+
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
-            enclaveURL: "router.inf6.tinfoil.sh",
+            enclaveURL: enclaveURL,
             expectedFingerprint: expectedFingerprint,
             parsingOptions: .relaxed
         )
@@ -59,13 +60,15 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testCertificatePinningFailure() async throws {
-        
-        // Create client with wrong fingerprint
+
+        let routerAddress = try await RouterManager.fetchRouter()
+        let enclaveURL = "https://\(routerAddress)"
+
         let wrongFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
-        
+
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
-            enclaveURL: "router.inf6.tinfoil.sh",
+            enclaveURL: enclaveURL,
             expectedFingerprint: wrongFingerprint
         )
         
@@ -129,17 +132,18 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testStreamingWithCertificatePinning() async throws {
-        
-        // Get the correct fingerprint from verification using a valid router URL
-        let secureClient = SecureClient(enclaveURL: "router.inf6.tinfoil.sh")
-        
+
+        let routerAddress = try await RouterManager.fetchRouter()
+        let enclaveURL = "https://\(routerAddress)"
+
+        let secureClient = SecureClient(enclaveURL: enclaveURL)
+
         let verificationResult = try await secureClient.verify()
         let expectedFingerprint = verificationResult.tlsPublicKey
-        
-        // Create client with correct fingerprint and relaxed parsing
+
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
-            enclaveURL: "router.inf6.tinfoil.sh",
+            enclaveURL: enclaveURL,
             expectedFingerprint: expectedFingerprint,
             parsingOptions: .relaxed
         )
@@ -166,13 +170,15 @@ final class TinfoilAITests: XCTestCase {
     }
     
     func testStreamingFailsWithWrongCertificate() async throws {
-        
-        // Create client with wrong fingerprint
+
+        let routerAddress = try await RouterManager.fetchRouter()
+        let enclaveURL = "https://\(routerAddress)"
+
         let wrongFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
-        
+
         let tinfoilClient = try TinfoilClient.create(
             apiKey: "tinfoil",
-            enclaveURL: "router.inf6.tinfoil.sh",
+            enclaveURL: enclaveURL,
             expectedFingerprint: wrongFingerprint
         )
         
@@ -342,8 +348,10 @@ final class TinfoilAITests: XCTestCase {
     }
 
     func testNewGroundTruthFieldsIntegration() async throws {
-        // Test that new GroundTruth fields are properly integrated
-        let secureClient = SecureClient(enclaveURL: "router.inf6.tinfoil.sh")
+        let routerAddress = try await RouterManager.fetchRouter()
+        let enclaveURL = "https://\(routerAddress)"
+
+        let secureClient = SecureClient(enclaveURL: enclaveURL)
 
         do {
             let groundTruth = try await secureClient.verify()

--- a/Tests/TinfoilIntegrationTests.swift
+++ b/Tests/TinfoilIntegrationTests.swift
@@ -45,7 +45,11 @@ final class TinfoilIntegrationTests: XCTestCase {
     }
 
     func testMissingAPIKeyError() async throws {
-        // Test that missing API key throws the correct error
+        let originalValue = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"]
+        guard originalValue == nil else {
+            throw XCTSkip("Skipping test: TINFOIL_API_KEY is set in environment")
+        }
+
         do {
             _ = try await TinfoilAI.create(
                 apiKey: nil,
@@ -53,7 +57,6 @@ final class TinfoilIntegrationTests: XCTestCase {
             )
             XCTFail("Should have thrown missingAPIKey error")
         } catch TinfoilError.missingAPIKey {
-            // Expected error
             XCTAssertTrue(true)
         } catch {
             XCTFail("Unexpected error: \(error)")

--- a/Tests/VerificationTests.swift
+++ b/Tests/VerificationTests.swift
@@ -7,10 +7,12 @@ final class VerificationTests: XCTestCase {
     // MARK: - New Verification Format Tests
 
     func testNewVerificationFormatFields() async throws {
-        // Test that new fields are properly populated when verification succeeds
+        let routerAddress = try await RouterManager.fetchRouter()
+        let enclaveURL = "https://\(routerAddress)"
+
         let secureClient = SecureClient(
             githubRepo: TinfoilConstants.defaultGithubRepo,
-            enclaveURL: "router.inf6.tinfoil.sh"
+            enclaveURL: enclaveURL
         )
 
         do {
@@ -92,10 +94,12 @@ final class VerificationTests: XCTestCase {
             }
         }
 
-        // Test 3: Invalid GitHub repo that should fail at verifyCode
+        let routerAddress = try await RouterManager.fetchRouter()
+        let enclaveURL = "https://\(routerAddress)"
+
         let invalidRepoClient = SecureClient(
             githubRepo: "invalid-org/non-existent-repo",
-            enclaveURL: "router.inf6.tinfoil.sh"
+            enclaveURL: enclaveURL
         )
 
         do {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated to TinfoilVerifier v0.10.16 and aligned SecureClient with the new ClientVerifyJSON signature. Tests now use dynamic router discovery, an env-based API key, and the gpt-oss-120b model for more reliable runs.

- **Dependencies**
  - Bumped TinfoilVerifier to v0.10.16 (new URL and checksum).

- **Tests**
  - Discover routers via RouterManager.fetchRouter() and build https://<router> URLs.
  - Read API key from TINFOIL_API_KEY; skip tests when it’s missing.
  - Switched test model to gpt-oss-120b.
  - Strengthened certificate pinning tests (success/failure, including streaming) and improved integration checks (verification callback, ground truth fields, invalid repo, missing API key).

<sup>Written for commit 2651fc2b443cbb537acc660ad9b3104e1912bb08. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

