### PR TITLE
Chore: clean up dead code and update packages 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/MacPaw/OpenAI.git",
       "state" : {
         "branch" : "main",
-        "revision" : "c8b02fc5e3ec1df6925158b52c64959408f86b84"
+        "revision" : "4ed3ea99ff9dfd2a760509ddb31020f4b153ef93"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
-        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
-        "version" : "1.4.0"
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "8f33cc5dfe81169fb167da73584b9c72c3e8bc23",
-        "version" : "1.8.2"
+        "revision" : "7722cf8eac05c1f1b5b05895b04cfcc29576d9be",
+        "version" : "1.8.3"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -84,11 +84,9 @@ for try await chunk in client.chatsStream(query: chatQuery) {
 }
 ```
 
-### Verification and Security
+### Security Architecture
 
-Tinfoil Swift performs two types of verification:
-1. **Attestation verification**: Validates the enclave is running genuine Tinfoil code
-2. **TLS certificate verification**: Ensures you're connecting to the verified enclave
+Tinfoil Swift combines **remote attestation** and **certificate pinning** to ensure your data only reaches verified enclave code. During setup, the SDK requests an attestation report that cryptographically proves the exact code running in the enclave and includes the enclave's TLS public key fingerprint. On every API request, the SDK validates the server's TLS certificate matches this attested fingerprint. This creates a cryptographic chain from GitHub source code → attestation → TLS connection, preventing man-in-the-middle attacks even if DNS or router selection is compromised.
 
 #### Verification Callback
 
@@ -141,8 +139,6 @@ For complete documentation, see:
 - iOS 17.0+ / macOS 12.0+
 - Swift 5.9+
 - Xcode 15.0+
-
-## Security
 
 ## Reporting Vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://github.com/tinfoilsh/tinfoil-swift/actions/workflows/test.yml/badge.svg)](https://github.com/tinfoilsh/tinfoil-swift/actions/workflows/test.yml)
 [![Docs](https://img.shields.io/badge/Docs-Swift%20SDK-blue.svg)](https://docs.tinfoil.sh/sdk/swift-sdk)
 
-A secure Swift SDK for communicating with AI models running in Tinfoil's confidential computing enclaves. This SDK wraps the [MacPaw OpenAI SDK](https://github.com/MacPaw/OpenAI) with additional security features including automatic enclave verification, certificate pinning, and attestation validation.
+A secure Swift SDK for communicating with AI models running in Tinfoil's confidential computing enclaves. This SDK configures the [MacPaw OpenAI SDK](https://github.com/MacPaw/OpenAI) with additional security features including automatic enclave attestation verification and certificate pinning for direct-to-enclave encrypted communication.
 
 ## Installation
 
@@ -59,8 +59,7 @@ print(response.choices.first?.message.content ?? "No response")
 - **Automatic Router Selection**: Dynamically selects from available Tinfoil routers
 - **Enclave Verification**: Verifies code integrity via GitHub and Sigstore
 - **Remote Attestation**: Validates the enclave runtime environment (AMD SEV-SNP / Intel TDX)
-- **Certificate Pinning**: Prevents man-in-the-middle attacks
-- **Streaming Support**: Real-time streaming responses
+- **Certificate Pinning**: Ensures direct-to-enclave encrypted communication
 - **OpenAI Compatible**: Drop-in replacement for OpenAI SDK
 
 ## Advanced Features
@@ -99,8 +98,10 @@ You can receive the verification document through an optional callback:
 let verificationCallback: VerificationCallback = { verificationDocument in
     if let doc = verificationDocument {
         print("✅ Attestation verification successful")
-        print("Code measurement: \(doc.codeMeasurement.registers.first ?? "")")
+        print("Code fingerprint: \(doc.codeFingerprint)")
+        print("Enclave fingerprint: \(doc.enclaveFingerprint)")
         print("Security verified: \(doc.securityVerified)")
+        print("All steps succeeded: \(doc.allStepsSucceeded)")
     }
 }
 
@@ -119,9 +120,9 @@ let client = try await TinfoilAI.create(
 let client = try await TinfoilAI.create(
     apiKey: String? = nil,              // API key (uses TINFOIL_API_KEY env var if nil)
     enclaveURL: String? = nil,           // Custom enclave URL (auto-selects router if nil)
-    githubRepo: String = "org/repo", // GitHub repo for verification (default: "tinfoilsh/confidential-model-router")
+    githubRepo: String = "tinfoilsh/confidential-model-router", // GitHub repo for verification
     parsingOptions: ParsingOptions = .relaxed,  // OpenAI parsing options
-    onVerification: ((VerificationDocument?) -> Void)? = nil // Verification callback
+    onVerification: VerificationCallback? = nil // Verification callback
 )
 
 // Returns: OpenAI - The configured OpenAI client
@@ -143,10 +144,12 @@ For complete documentation, see:
 
 ## Security
 
-### Reporting Vulnerabilities
+## Reporting Vulnerabilities
 
-Please report security vulnerabilities to [security@tinfoil.sh](mailto:security@tinfoil.sh) or by opening an issue on GitHub.
+Please report security vulnerabilities by either:
 
-## License
+- Emailing [security@tinfoil.sh](mailto:security@tinfoil.sh)
 
-GNU Affero General Public License (AGPL) v3.0
+- Opening an issue on GitHub on this repository
+
+We aim to respond to (legitimate) security reports within 24 hours.

--- a/Sources/TinfoilAI/URLSessionPinning.swift
+++ b/Sources/TinfoilAI/URLSessionPinning.swift
@@ -6,13 +6,6 @@ import Security
 /// - Parameter verificationDocument: The verification document from attestation
 public typealias VerificationCallback = @Sendable (VerificationDocument?) -> Void
 
-/// Custom error type for certificate verification failures
-public enum CertificateVerificationError: Error {
-    case fingerprintMismatch(String, String)
-    case noCertificate
-    case verificationFailed(Error)
-}
-
 /// A URLSession delegate that performs certificate pinning and extraction
 public class CertificatePinningDelegate: NSObject, URLSessionDelegate {
     private let expectedFingerprint: String

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -1,43 +1,12 @@
 import Foundation
 import TinfoilVerifier
 
-/// Represents the status of a verification step
-public enum VerificationStatus {
-    case pending
-    case inProgress
-    case success
-    case failure(Error)
-}
-
 /// Errors that can occur during verification
 public enum VerificationError: Error {
     case verificationFailed(String)
     case jsonDecodingFailed(String)
     case unknown(Error)
 }
-
-/// Contains verification result information for a step
-public struct StepResult {
-    public let status: VerificationStatus
-    public let digest: String?
-    
-    public static func pending() -> StepResult {
-        return StepResult(status: .pending, digest: nil)
-    }
-    
-    public static func inProgress() -> StepResult {
-        return StepResult(status: .inProgress, digest: nil)
-    }
-    
-    public static func success(digest: String) -> StepResult {
-        return StepResult(status: .success, digest: digest)
-    }
-    
-    public static func failure(_ error: Error) -> StepResult {
-        return StepResult(status: .failure(error), digest: nil)
-    }
-}
-
 
 /// Measurement structure matching Go's attestation.Measurement
 public struct Measurement: Codable {

--- a/Tests/VerificationTests.swift
+++ b/Tests/VerificationTests.swift
@@ -45,9 +45,6 @@ final class VerificationTests: XCTestCase {
             XCTAssertFalse(verificationDoc?.selectedRouterEndpoint.isEmpty ?? true, "Router endpoint should be populated")
         } catch {
             // If this fails in CI, it might be due to network issues
-            // We should at least verify the error is a known type
-            XCTAssertTrue(error is NSError || error is VerificationError,
-                         "Error should be a known type: \(error)")
         }
     }
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up dead code, improved certificate pinning to support multiple EC curves, and updated packages. Also refreshed the README to clearly explain the attestation → TLS security chain and fixed test warnings.

- **New Features**
  - Certificate pinning now converts raw EC keys to SPKI and supports P-256, P-384, and P-521.

- **Dependencies**
  - Updated swift-http-types to 1.5.1 and swift-openapi-runtime to 1.8.3.
  - Bumped MacPaw OpenAI to latest main revision.

<sup>Written for commit 70ed727293a197298c6abe383e198c16bd1120f5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



