### PR TITLE
chore: bump openai

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/MacPaw/OpenAI.git", branch: "main"),
+        .package(url: "https://github.com/MacPaw/OpenAI.git", exact: "0.4.7"),
     ],
     targets: [
         .binaryTarget(

--- a/update_openai.sh
+++ b/update_openai.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+LATEST_TAG=$(curl -sL https://api.github.com/repos/MacPaw/OpenAI/releases/latest | jq -r ".tag_name")
+
+echo "OpenAI package latest version: $LATEST_TAG"
+
+sed -i '.bak' -E "s|(url: \"https://github.com/MacPaw/OpenAI.git\", exact: \")[0-9]+\.[0-9]+\.[0-9]+(\")|\1$LATEST_TAG\2|" Package.swift
+
+git add .
+git commit -m "chore: bump openai"
+echo "Update completed and commit created. Push to remote."


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin the OpenAI Swift package to v0.4.7 to avoid breakages from upstream changes and ensure reproducible builds. Added a small script to bump the dependency to the latest release when needed.

- **Dependencies**
  - Pinned MacPaw/OpenAI to exact 0.4.7 (was tracking main).
  - Added update_openai.sh to fetch the latest tag, update Package.swift, and create a commit.

<sup>Written for commit deed59c4e73513796edc952095b14aac42281a32. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

