### PR TITLE
fix: build warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MacPaw/OpenAI.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "4ed3ea99ff9dfd2a760509ddb31020f4b153ef93"
+        "revision" : "28884fcfb15946b119b6eb3498e5a900c1d8d595",
+        "version" : "0.4.7"
       }
     },
     {

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -391,7 +391,7 @@ final class TinfoilAITests: XCTestCase {
                 XCTAssertFalse(hwMeasurement.rtmr0.isEmpty, "RTMR0 should exist if present")
             }
 
-        } catch let error as VerificationError {
+        } catch is VerificationError {
             // Verification errors are acceptable (may occur due to network issues in CI)
         } catch {
             XCTFail("Unexpected error type: \(error)")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes build warnings by pinning MacPaw/OpenAI to v0.4.7 and removing an unused error binding in tests. This stabilizes dependency resolution and cleans up CI logs.

<sup>Written for commit 3c0c32f5a56d28b3af041deca320bda3c9e23ebc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

