### PR TITLE
fix: set default concurrency level

### DIFF
--- a/Sources/TinfoilAI/URLSessionPinning.swift
+++ b/Sources/TinfoilAI/URLSessionPinning.swift
@@ -100,11 +100,13 @@ public class SecureURLSessionFactory {
         // Disable caching for security
         configuration.urlCache = nil
         configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        
-        // Use a specific operation queue for delegate callbacks to ensure thread safety
+
+        // Use a specific operation queue for delegate callbacks
+        // Allow concurrent operations since delegate methods are thread-safe
+        // (HTTP/2 handles multiplexing over a single connection)
         let delegateQueue = OperationQueue()
-        delegateQueue.maxConcurrentOperationCount = 1 // Serial queue for thread safety
-        
+        delegateQueue.maxConcurrentOperationCount = OperationQueue.defaultMaxConcurrentOperationCount
+
         return URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
     }
 } 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the URLSession delegate queue from serial to the default concurrent level to improve throughput for HTTP/2 requests. Delegate callbacks remain thread-safe, and caching stays disabled for security.

<sup>Written for commit b142ecf04d40ba339c12b0560db5359e8f5c2ac9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

