### PR TITLE
fix: use semver-compatible versioning for deps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", branch: "main"),
-        .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", branch: "main"),
+        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", from: "0.0.1"),
+        .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.1.4"),
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch SwiftPM dependencies from tracking main branches to semver “from” constraints to ensure stable, reproducible builds and safer updates.

- **Dependencies**
  - openai-swift-fork: main → from 0.0.1
  - encrypted-http-body-protocol: main → from 0.1.4

<sup>Written for commit 2b5950edfb9baf02bbd88f2ab446eea4caa14ad9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

