### PR TITLE
Add proxy support with baseURL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ let client = try await TinfoilAI.create(
 ```swift
 let client = try await TinfoilAI.create(
     apiKey: String? = nil,              // API key (uses TINFOIL_API_KEY env var if nil)
-    enclaveURL: String? = nil,           // Custom enclave URL (auto-selects router if nil)
+    baseURL: String? = nil,             // Proxy server URL (requests go directly to enclave if nil)
+    enclaveURL: String? = nil,          // Custom enclave URL (auto-selects router if nil)
     githubRepo: String = "tinfoilsh/confidential-model-router", // GitHub repo for verification
     parsingOptions: ParsingOptions = .relaxed,  // OpenAI parsing options
     onVerification: VerificationCallback? = nil // Verification callback
@@ -125,6 +126,10 @@ let client = try await TinfoilAI.create(
 
 // Returns: TinfoilAI - A client with the same API as OpenAI
 ```
+
+### Proxy Server Support
+
+See the [Proxy Server Guide](https://docs.tinfoil.sh/guides/proxy-server) for routing requests through a proxy while maintaining end-to-end encryption.
 
 ## API Documentation
 

--- a/Sources/TinfoilAI/EHBPURLSession.swift
+++ b/Sources/TinfoilAI/EHBPURLSession.swift
@@ -231,9 +231,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
             }
 
             if let enclaveURL = enclaveURL, !enclaveURL.isEmpty {
-                let baseOrigin = URL(string: baseURL)?.host ?? ""
-                let enclaveOrigin = URL(string: enclaveURL)?.host ?? ""
-                if baseOrigin != enclaveOrigin {
+                if URLHelpers.origin(from: baseURL) != URLHelpers.origin(from: enclaveURL) {
                     headers[enclaveURLHeaderName] = enclaveURL
                 }
             }
@@ -377,9 +375,7 @@ public final class EHBPURLSession: URLSessionProtocol, @unchecked Sendable {
         }
 
         if let enclaveURL = enclaveURL, !enclaveURL.isEmpty {
-            let baseOrigin = URL(string: baseURL)?.host ?? ""
-            let enclaveOrigin = URL(string: enclaveURL)?.host ?? ""
-            if baseOrigin != enclaveOrigin {
+            if URLHelpers.origin(from: baseURL) != URLHelpers.origin(from: enclaveURL) {
                 headers[enclaveURLHeaderName] = enclaveURL
             }
         }

--- a/Sources/TinfoilAI/URLHelpers.swift
+++ b/Sources/TinfoilAI/URLHelpers.swift
@@ -40,4 +40,12 @@ internal enum URLHelpers {
     static func buildHostWithPort(host: String, port: Int?) -> String {
         return port != nil ? "\(host):\(port!)" : host
     }
+
+    /// Extracts the origin (host:port) from a URL string for comparison
+    /// - Parameter urlString: The URL string to extract origin from
+    /// - Returns: The origin string (host:port or just host), or empty string if invalid
+    static func origin(from urlString: String) -> String {
+        guard let components = try? parseURL(urlString) else { return "" }
+        return buildHostWithPort(host: components.host, port: components.port)
+    }
 } 

--- a/Sources/TinfoilAI/URLHelpers.swift
+++ b/Sources/TinfoilAI/URLHelpers.swift
@@ -41,11 +41,12 @@ internal enum URLHelpers {
         return port != nil ? "\(host):\(port!)" : host
     }
 
-    /// Extracts the origin (host:port) from a URL string for comparison
+    /// Extracts the origin (scheme://host:port) from a URL string for comparison
     /// - Parameter urlString: The URL string to extract origin from
-    /// - Returns: The origin string (host:port or just host), or empty string if invalid
+    /// - Returns: The origin string (scheme://host:port), or empty string if invalid
     static func origin(from urlString: String) -> String {
         guard let components = try? parseURL(urlString) else { return "" }
-        return buildHostWithPort(host: components.host, port: components.port)
+        let hostWithPort = buildHostWithPort(host: components.host, port: components.port)
+        return "\(components.scheme)://\(hostWithPort)"
     }
 } 

--- a/Tests/EHBPTests.swift
+++ b/Tests/EHBPTests.swift
@@ -619,6 +619,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIChatsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -666,6 +667,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIChatsStreamUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -713,6 +715,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIEmbeddingsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -756,6 +759,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIImagesUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -799,6 +803,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAICreateResponseUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -842,6 +847,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAICreateResponseStreamUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -888,6 +894,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIModerationsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -927,6 +934,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIImageEditsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -957,6 +965,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIImageVariationsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -984,6 +993,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAudioCreateSpeechUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1025,6 +1035,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAudioTranscriptionsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1056,6 +1067,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAudioTranslationsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1087,6 +1099,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAssistantCreateUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1130,6 +1143,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIThreadsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1160,6 +1174,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIThreadRunUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1203,6 +1218,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIRunsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1230,6 +1246,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIThreadsAddMessageUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1267,6 +1284,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIFilesUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1303,6 +1321,7 @@ final class EHBPTests: XCTestCase {
         XCTAssertThrowsError(
             try TinfoilAI(
                 apiKey: "test-api-key",
+                baseURL: "https://example.com",
                 enclaveURL: "https://example.com",
                 hpkePublicKeyHex: nil
             ),
@@ -1325,6 +1344,7 @@ final class EHBPTests: XCTestCase {
         XCTAssertThrowsError(
             try TinfoilAI(
                 apiKey: "test-api-key",
+                baseURL: "https://example.com",
                 enclaveURL: "https://example.com",
                 hpkePublicKeyHex: ""
             ),
@@ -1349,6 +1369,7 @@ final class EHBPTests: XCTestCase {
     func testAllPOSTRequestsHaveNonEmptyBodies() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1567,6 +1588,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAudioCreateSpeechStreamUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1607,6 +1629,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAudioTranscriptionsVerboseUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1639,6 +1662,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAudioTranscriptionStreamUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1669,6 +1693,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIAssistantModifyUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )
@@ -1712,6 +1737,7 @@ final class EHBPTests: XCTestCase {
     func testTinfoilAIRunSubmitToolOutputsUsesEHBPEncryption() async throws {
         let tinfoilClient = try TinfoilAI(
             apiKey: "test-api-key",
+            baseURL: server.baseURL,
             enclaveURL: server.baseURL,
             hpkePublicKeyHex: testPublicKey.hexString
         )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds first-class proxy support via a new baseURL parameter so requests can go through a proxy while preserving EHBP end-to-end encryption and enclave verification. Default behavior is unchanged if baseURL is not provided.

- **New Features**
  - Added baseURL to TinfoilAI.create (and internal initializer). Requests are sent to baseURL; enclaveURL is still verified.
  - EHBPURLSession and streaming factory now accept enclaveURL and set X-Tinfoil-Enclave-Url when origins differ, so proxies can forward correctly.
  - Defaults to direct-to-enclave when baseURL is nil; remains backward compatible.
  - Updated README with a Proxy Server Support section and link to the guide; tests updated to use the new interface.

<sup>Written for commit c15ae54debce9e6137826b9cb26729844da7b875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

