### PR TITLE
fix: pass host and port separately to OpenAI configuration

### DIFF
--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -100,11 +100,12 @@ public class TinfoilAI {
         )
 
         let urlComponents = try URLHelpers.parseURL(baseURL)
-        let hostWithPort = URLHelpers.buildHostWithPort(host: urlComponents.host, port: urlComponents.port)
+        let defaultPort = urlComponents.scheme == "https" ? 443 : 80
 
         let configuration = OpenAI.Configuration(
             token: apiKey,
-            host: hostWithPort,
+            host: urlComponents.host,
+            port: urlComponents.port ?? defaultPort,
             scheme: urlComponents.scheme,
             parsingOptions: parsingOptions
         )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix OpenAI client setup by passing host and port separately and using scheme-based default ports. This avoids malformed host values and ensures URLs without an explicit port connect correctly.

<sup>Written for commit c32c7c497085afbd603a4bb206a8779fdbb0b136. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

