### PR TITLE
chore: update openai-swift pkg

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", from: "0.0.1"),
+        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.3"),
         .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.1.5"),
     ],
     targets: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins openai-swift-fork to 0.0.3 (exact) in Package.swift to ensure reproducible builds and avoid unexpected updates. Replaces the previous "from: 0.0.1" requirement.

<sup>Written for commit 79cb8f532b5fe2a24ccda2c4ddbe0c1749c5f59c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

