### PR TITLE
feat: expose web search events in sdk

### DIFF
--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -127,6 +127,13 @@ public class TinfoilAI {
         openAIClient.chatsStream(query: query)
     }
 
+    public func chatsStream(
+        query: ChatQuery,
+        onWebSearchEvent: @escaping @Sendable (WebSearchEvent) -> Void
+    ) -> AsyncThrowingStream<ChatStreamResult, Error> {
+        openAIClient.chatsStream(query: query, onWebSearchEvent: onWebSearchEvent)
+    }
+
     public func images(query: ImagesQuery) async throws -> ImagesResult {
         try await openAIClient.images(query: query)
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose web search events to SDK consumers by adding a new chatsStream(query:onWebSearchEvent:) overload that forwards the callback to the underlying client. This lets clients handle WebSearchEvent updates during streaming without breaking the existing API.

<sup>Written for commit 67fac99485e6b826c69237645d338079e0aa884e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

