### PR TITLE
chore: update verifier path and bump version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "TinfoilVerifier",
-            url: "https://github.com/tinfoilsh/verifier/releases/download/v0.11.2/TinfoilVerifier.xcframework.zip",
-            checksum: "6475f9b816f07b5f6a71fbba94a872fc7bb268bbdb4428774fd524bea5be5e0e"),
+            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/verifier/v0.12.0/TinfoilVerifier.xcframework.zip",
+            checksum: "ed74ae241497c76613c8bd12490171518cfd79f3c42cafb6113c60968404679c"),
         .target(
             name: "TinfoilAI",
             dependencies: [

--- a/update_verifier.sh
+++ b/update_verifier.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -e
 
-LATEST_TAG=$(curl -sL https://api.github.com/repos/tinfoilsh/verifier/releases/latest | jq -r ".tag_name")
+LATEST_TAG=$(curl -sL https://api.github.com/repos/tinfoilsh/tinfoil-go/releases | jq -r '[.[] | select(.tag_name | startswith("verifier/"))][0].tag_name')
 
-ZIP_FILE="verifier-$LATEST_TAG.zip"
+ZIP_FILE="verifier-${LATEST_TAG##*/}.zip"
 if [ ! -f "$ZIP_FILE" ]; then
-    wget -O "$ZIP_FILE" "https://github.com/tinfoilsh/verifier/releases/download/$LATEST_TAG/TinfoilVerifier.xcframework.zip"
+    wget -O "$ZIP_FILE" "https://github.com/tinfoilsh/tinfoil-go/releases/download/$LATEST_TAG/TinfoilVerifier.xcframework.zip"
 fi
 
 CHECKSUM=$(sha256sum "$ZIP_FILE" | cut -d ' ' -f 1)
 
 echo "Verifier framework $LATEST_TAG checksum: $CHECKSUM"
 
-sed -i '.bak' -E "s|(url: \"https://github.com/tinfoilsh/verifier/releases/download/)v[0-9]+\.[0-9]+\.[0-9]+(/TinfoilVerifier.xcframework.zip\")|\1$LATEST_TAG\2|" Package.swift
+sed -i '.bak' -E "s|(url: \"https://github.com/tinfoilsh/tinfoil-go/releases/download/)verifier/v[0-9]+\.[0-9]+\.[0-9]+(/TinfoilVerifier.xcframework.zip\")|\1$LATEST_TAG\2|" Package.swift
 sed -i '.bak' -E "s/(checksum: \")[a-f0-9]+(\")/\1$CHECKSUM\2/" Package.swift
 
 git add .


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the TinfoilVerifier binary to the new tinfoilsh/tinfoil-go release path and bump to v0.12.0. Updated the update_verifier.sh script to fetch the latest verifier tag and refresh the checksum automatically.

- **Dependencies**
  - Switched binary target to tinfoilsh/tinfoil-go releases (verifier/v0.12.0) and updated checksum.

- **Refactors**
  - Updated update_verifier.sh to select tags starting with "verifier/", adjust URLs and filename, and update sed patterns for Package.swift.

<sup>Written for commit c0c4280dfcdc7766a9db96b8514c837e36ec625b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

