### PR TITLE
feat: switch to tinfoil xcframework and add secureclient methods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,15 +18,15 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(
-            name: "TinfoilVerifier",
-            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/verifier/v0.12.0/TinfoilVerifier.xcframework.zip",
-            checksum: "ed74ae241497c76613c8bd12490171518cfd79f3c42cafb6113c60968404679c"),
+            name: "Tinfoil",
+            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.12.3/Tinfoil.xcframework.zip",
+            checksum: "3e67b7e5cdf92b511cae1c184891619b430bcc83c3e5605172f5d30701b496d7"),
         .target(
             name: "TinfoilAI",
             dependencies: [
                 .product(name: "OpenAI", package: "openai-swift-fork"),
                 .product(name: "EHBP", package: "encrypted-http-body-protocol"),
-                "TinfoilVerifier"
+                "Tinfoil"
             ],
             path: "Sources/TinfoilAI",
             linkerSettings: [

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -1,10 +1,25 @@
 import Foundation
-import TinfoilVerifier
+import Tinfoil
+
+/// Response from an attested HTTP request
+public struct SecureResponse: Sendable {
+    /// HTTP status code
+    public let statusCode: Int
+
+    /// Response body data
+    public let body: Data
+
+    /// Response body as a UTF-8 string
+    public var bodyString: String? {
+        String(data: body, encoding: .utf8)
+    }
+}
 
 /// Errors that can occur during verification
 public enum VerificationError: Error {
     case verificationFailed(String)
     case jsonDecodingFailed(String)
+    case notVerified
     case unknown(Error)
 }
 
@@ -60,6 +75,7 @@ public class SecureClient {
     private var discoveredEnclaveURL: String?
     private var groundTruth: GroundTruth?
     private var lastVerificationDocument: VerificationDocument?
+    private var goClient: ClientSecureClient?
 
     /// Initialize a secure client for direct enclave verification
     /// - Parameters:
@@ -113,14 +129,14 @@ public class SecureClient {
 
             if let attestationBundleURL = attestationBundleURL, !attestationBundleURL.isEmpty {
                 // Verification using custom attestation bundle URL
-                jsonString = TinfoilVerifier.ClientFetchAndVerifyFromURLJSON(attestationBundleURL, githubRepo, nil, &error)
+                jsonString = Tinfoil.ClientFetchAndVerifyFromURLJSON(attestationBundleURL, githubRepo, nil, &error)
             } else if let configuredEnclaveURL = configuredEnclaveURL {
                 // Direct enclave verification
                 let urlComponents = try URLHelpers.parseURL(configuredEnclaveURL)
-                jsonString = TinfoilVerifier.ClientVerifyJSON(urlComponents.host, githubRepo, nil, &error)
+                jsonString = Tinfoil.ClientVerifyJSON(urlComponents.host, githubRepo, nil, &error)
             } else {
                 // Default: fetch from Tinfoil's attestation bundle URL
-                jsonString = TinfoilVerifier.ClientFetchAndVerifyJSON(githubRepo, nil, &error)
+                jsonString = Tinfoil.ClientFetchAndVerifyJSON(githubRepo, nil, &error)
             }
 
             if let error = error {
@@ -221,6 +237,72 @@ public class SecureClient {
             buildFailureDocument(error: decodingError, steps: steps)
             throw decodingError
         }
+    }
+
+    // MARK: - Attested HTTP Requests
+
+    /// Returns the Go SecureClient, creating it if needed from verified enclave info
+    private func getGoClient() throws -> ClientSecureClient {
+        if let existing = goClient {
+            return existing
+        }
+
+        guard let groundTruth = groundTruth else {
+            throw VerificationError.notVerified
+        }
+
+        guard let host = groundTruth.enclaveHost ?? (configuredEnclaveURL.flatMap { try? URLHelpers.parseURL($0).host }) else {
+            throw VerificationError.verificationFailed("No enclave host available")
+        }
+
+        guard let client = ClientNewSecureClient(host, githubRepo) else {
+            throw VerificationError.verificationFailed("Failed to create secure client for \(host)")
+        }
+        goClient = client
+        return client
+    }
+
+    /// Makes an attested HTTP GET request to the verified enclave
+    /// - Parameters:
+    ///   - url: The URL to request (absolute or relative path)
+    ///   - headers: Optional HTTP headers
+    /// - Returns: The response with status code and body
+    public func get(url: String, headers: [String: String]? = nil) async throws -> SecureResponse {
+        let client = try getGoClient()
+        let headersJSON = try encodeHeaders(headers)
+
+        let response = try client.secureGet(url, headersJSON: headersJSON)
+
+        return SecureResponse(
+            statusCode: response.statusCode,
+            body: response.body ?? Data()
+        )
+    }
+
+    /// Makes an attested HTTP POST request to the verified enclave
+    /// - Parameters:
+    ///   - url: The URL to request (absolute or relative path)
+    ///   - headers: Optional HTTP headers
+    ///   - body: Optional request body
+    /// - Returns: The response with status code and body
+    public func post(url: String, headers: [String: String]? = nil, body: Data? = nil) async throws -> SecureResponse {
+        let client = try getGoClient()
+        let headersJSON = try encodeHeaders(headers)
+
+        let response = try client.securePost(url, headersJSON: headersJSON, body: body)
+
+        return SecureResponse(
+            statusCode: response.statusCode,
+            body: response.body ?? Data()
+        )
+    }
+
+    private func encodeHeaders(_ headers: [String: String]?) throws -> String {
+        guard let headers = headers, !headers.isEmpty else {
+            return ""
+        }
+        let data = try JSONSerialization.data(withJSONObject: headers)
+        return String(data: data, encoding: .utf8) ?? ""
     }
 
     /// Maps error message prefixes to verification step states

--- a/Tests/VerificationTests.swift
+++ b/Tests/VerificationTests.swift
@@ -229,6 +229,131 @@ final class VerificationTests: XCTestCase {
         XCTAssertEqual(testDoc.hardwareMeasurement?.id, "TDX-1")
     }
 
+    // MARK: - SecureClient HTTP Methods
+
+    func testGetBeforeVerifyThrowsNotVerified() async {
+        let client = SecureClient(githubRepo: TinfoilConstants.defaultGithubRepo)
+
+        do {
+            _ = try await client.get(url: "/health")
+            XCTFail("Should throw when calling get() before verify()")
+        } catch let error as VerificationError {
+            if case .notVerified = error {
+                // Expected
+            } else {
+                XCTFail("Expected VerificationError.notVerified, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected VerificationError, got \(error)")
+        }
+    }
+
+    func testPostBeforeVerifyThrowsNotVerified() async {
+        let client = SecureClient(githubRepo: TinfoilConstants.defaultGithubRepo)
+
+        do {
+            _ = try await client.post(url: "/api/test", body: Data())
+            XCTFail("Should throw when calling post() before verify()")
+        } catch let error as VerificationError {
+            if case .notVerified = error {
+                // Expected
+            } else {
+                XCTFail("Expected VerificationError.notVerified, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected VerificationError, got \(error)")
+        }
+    }
+
+    func testSecureGetAfterVerify() async throws {
+        let client = SecureClient(githubRepo: TinfoilConstants.defaultGithubRepo)
+
+        do {
+            _ = try await client.verify()
+        } catch {
+            throw XCTSkip("Verification failed (network issue): \(error)")
+        }
+
+        let response = try await client.get(url: "/v1/models")
+        XCTAssertTrue([200, 401].contains(response.statusCode),
+                      "Models endpoint should return 200 or 401 (no API key)")
+        XCTAssertNotNil(response.bodyString)
+    }
+
+    func testSecureGetWithHeaders() async throws {
+        let client = SecureClient(githubRepo: TinfoilConstants.defaultGithubRepo)
+
+        do {
+            _ = try await client.verify()
+        } catch {
+            throw XCTSkip("Verification failed (network issue): \(error)")
+        }
+
+        let apiKey = ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? ""
+        let response = try await client.get(
+            url: "/v1/models",
+            headers: [
+                "Accept": "application/json",
+                "Authorization": "Bearer \(apiKey)"
+            ]
+        )
+        XCTAssertTrue([200, 401].contains(response.statusCode))
+    }
+
+    func testSecurePostWithBody() async throws {
+        let client = SecureClient(githubRepo: TinfoilConstants.defaultGithubRepo)
+
+        do {
+            _ = try await client.verify()
+        } catch {
+            throw XCTSkip("Verification failed (network issue): \(error)")
+        }
+
+        let body = try JSONSerialization.data(withJSONObject: [
+            "model": "gpt-oss-120b",
+            "messages": [["role": "user", "content": "Say hi"]],
+            "max_tokens": 5
+        ])
+
+        let response = try await client.post(
+            url: "/v1/chat/completions",
+            headers: [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(ProcessInfo.processInfo.environment["TINFOIL_API_KEY"] ?? "")"
+            ],
+            body: body
+        )
+
+        XCTAssertTrue([200, 401].contains(response.statusCode),
+                      "Should get 200 (success) or 401 (no API key in CI)")
+        XCTAssertNotNil(response.bodyString, "Response should have a body")
+    }
+
+    func testSecureResponseBodyString() {
+        let data = "hello world".data(using: .utf8)!
+        let response = SecureResponse(statusCode: 200, body: data)
+
+        XCTAssertEqual(response.bodyString, "hello world")
+        XCTAssertEqual(response.statusCode, 200)
+    }
+
+    func testSecureGetWithNilAndEmptyHeaders() async throws {
+        let client = SecureClient(githubRepo: TinfoilConstants.defaultGithubRepo)
+
+        do {
+            _ = try await client.verify()
+        } catch {
+            throw XCTSkip("Verification failed (network issue): \(error)")
+        }
+
+        // Verify nil and empty headers don't crash
+        let response = try await client.get(url: "/v1/models", headers: nil)
+        XCTAssertTrue([200, 401].contains(response.statusCode))
+
+        let response2 = try await client.get(url: "/v1/models", headers: [:])
+        XCTAssertEqual(response.statusCode, response2.statusCode)
+    }
+
     // MARK: - Step Status Tests
 
     func testVerificationStepStatuses() {

--- a/Tests/VerificationTests.swift
+++ b/Tests/VerificationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import TinfoilAI
-import TinfoilVerifier
+import Tinfoil
 
 final class VerificationTests: XCTestCase {
 

--- a/update_verifier.sh
+++ b/update_verifier.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -e
 
-LATEST_TAG=$(curl -sL https://api.github.com/repos/tinfoilsh/tinfoil-go/releases | jq -r '[.[] | select(.tag_name | startswith("verifier/"))][0].tag_name')
+LATEST_TAG=$(curl -sL https://api.github.com/repos/tinfoilsh/tinfoil-go/releases | jq -r '[.[] | select(.tag_name | test("^v[0-9]"))][0].tag_name')
 
-ZIP_FILE="verifier-${LATEST_TAG##*/}.zip"
+ZIP_FILE="tinfoil-${LATEST_TAG}.zip"
 if [ ! -f "$ZIP_FILE" ]; then
-    wget -O "$ZIP_FILE" "https://github.com/tinfoilsh/tinfoil-go/releases/download/$LATEST_TAG/TinfoilVerifier.xcframework.zip"
+    wget -O "$ZIP_FILE" "https://github.com/tinfoilsh/tinfoil-go/releases/download/$LATEST_TAG/Tinfoil.xcframework.zip"
 fi
 
 CHECKSUM=$(sha256sum "$ZIP_FILE" | cut -d ' ' -f 1)
 
-echo "Verifier framework $LATEST_TAG checksum: $CHECKSUM"
+echo "Tinfoil framework $LATEST_TAG checksum: $CHECKSUM"
 
-sed -i '.bak' -E "s|(url: \"https://github.com/tinfoilsh/tinfoil-go/releases/download/)verifier/v[0-9]+\.[0-9]+\.[0-9]+(/TinfoilVerifier.xcframework.zip\")|\1$LATEST_TAG\2|" Package.swift
+sed -i '.bak' -E "s|(url: \"https://github.com/tinfoilsh/tinfoil-go/releases/download/)v[0-9]+\.[0-9]+\.[0-9]+(/Tinfoil.xcframework.zip\")|\1$LATEST_TAG\2|" Package.swift
 sed -i '.bak' -E "s/(checksum: \")[a-f0-9]+(\")/\1$CHECKSUM\2/" Package.swift
 
 git add .


### PR DESCRIPTION
Updates binary target from TinfoilVerifier to Tinfoil xcframework, adds get() and post() methods on SecureClient for making TLS-pinned HTTP requests through the verified enclave, and updates the verifier update script for the new release tag pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the binary target to the `Tinfoil` xcframework and adds attested HTTP `get` and `post` on `SecureClient` for TLS‑pinned requests through the verified enclave. Caches the Go secure client after verification and adds tests for pre/post verification behavior.

- **New Features**
  - Added `SecureClient.get(url:headers:)` and `SecureClient.post(url:headers:body:)` for attested requests.
  - Returns `SecureResponse` with `statusCode` and `body` (plus `bodyString`).
  - New `VerificationError.notVerified` when requests are made before verification.
  - Caches the Go secure client after successful verification to reuse for requests.
  - Tests cover pre‑verify errors, header/body handling, and response string parsing.

- **Dependencies**
  - Replaced `TinfoilVerifier` with `Tinfoil` xcframework in `Package.swift` (v0.12.3, new checksum).
  - Updated imports from `TinfoilVerifier` to `Tinfoil` (including tests).
  - Updated `update_verifier.sh` for new tag pattern and `Tinfoil.xcframework.zip` URL, and adjusted checksum/URL replacements.

<sup>Written for commit d310e9f478236c244c9136102e10511a82d69485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

