### PR TITLE
revert: package name change

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,14 +2,14 @@
 import PackageDescription
 
 let package = Package(
-    name: "Tinfoil",
+    name: "tinfoil-swift",
     platforms: [
         .macOS(.v14),
         .iOS(.v17)
     ],
     products: [
         .library(
-            name: "Tinfoil",
+            name: "TinfoilAI",
             targets: ["TinfoilAI"]),
     ],
     dependencies: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renames the package from `Tinfoil` to `tinfoil-swift` and the library product from `Tinfoil` to `TinfoilAI` in `Package.swift`.

<sup>Written for commit c129b308f9a136bd9ef192357d9ea227c14e9e73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

