### PR TITLE
Refactor: drop legacy websearch code and add support for headers 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.4"),
+        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.5"),
         .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.1.5"),
     ],
     targets: [

--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -118,7 +118,7 @@ public class TinfoilAI {
 
         var mergedHeaders = customHeaders
         if let eventsHeader = tinfoilEventsHeaderValue(tinfoilEvents),
-           mergedHeaders[tinfoilEventsHeader] == nil {
+           !mergedHeaders.keys.contains(where: { $0.caseInsensitiveCompare(tinfoilEventsHeader) == .orderedSame }) {
             mergedHeaders[tinfoilEventsHeader] = eventsHeader
         }
 

--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -20,6 +20,16 @@ public class TinfoilAI {
     ///     If not provided, uses the default Tinfoil endpoint. The enclave URL is discovered from
     ///     the attestation bundle during verification.
     ///   - parsingOptions: Parsing options for handling different providers.
+    ///   - customHeaders: Additional request headers to forward verbatim on
+    ///     every outbound request (merged over the headers synthesized by
+    ///     `tinfoilEvents`; caller values win on conflict). Use for arbitrary
+    ///     router / proxy pass-through headers.
+    ///   - tinfoilEvents: Optional set of Tinfoil-specific progress events
+    ///     to opt into. Each selected event contributes one comma-separated
+    ///     value on the `X-Tinfoil-Events` request header so the router
+    ///     emits `<tinfoil-event>...</tinfoil-event>` markers inline with
+    ///     the assistant text. Strict OpenAI SDKs render the markers as
+    ///     text; callers parse and strip them before display.
     ///   - onVerification: Optional callback for verification results
     /// - Returns: A TinfoilAI client configured for secure communication (use like OpenAI client)
     ///
@@ -33,6 +43,8 @@ public class TinfoilAI {
         githubRepo: String = TinfoilConstants.defaultGithubRepo,
         attestationBundleURL: String? = nil,
         parsingOptions: ParsingOptions = .relaxed,
+        customHeaders: [String: String] = [:],
+        tinfoilEvents: Set<TinfoilEvent> = [],
         onVerification: VerificationCallback? = nil
     ) async throws -> TinfoilAI {
         let finalApiKey = apiKey ?? ProcessInfo.processInfo.environment["TINFOIL_API_KEY"]
@@ -61,7 +73,9 @@ public class TinfoilAI {
                 baseURL: finalBaseURL,
                 enclaveURL: enclaveURL,
                 hpkePublicKeyHex: groundTruth.hpkePublicKey,
-                parsingOptions: parsingOptions
+                parsingOptions: parsingOptions,
+                customHeaders: customHeaders,
+                tinfoilEvents: tinfoilEvents
             )
         } catch {
             onVerification?(verifier.verificationDocument)
@@ -75,7 +89,9 @@ public class TinfoilAI {
         baseURL: String,
         enclaveURL: String,
         hpkePublicKeyHex: String?,
-        parsingOptions: ParsingOptions = .relaxed
+        parsingOptions: ParsingOptions = .relaxed,
+        customHeaders: [String: String] = [:],
+        tinfoilEvents: Set<TinfoilEvent> = []
     ) throws {
         guard let hpkeKeyHex = hpkePublicKeyHex, !hpkeKeyHex.isEmpty else {
             throw TinfoilError.invalidConfiguration("Server does not support EHBP (no HPKE public key)")
@@ -100,11 +116,18 @@ public class TinfoilAI {
         let urlComponents = try URLHelpers.parseURL(baseURL)
         let defaultPort = urlComponents.scheme == "https" ? 443 : 80
 
+        var mergedHeaders = customHeaders
+        if let eventsHeader = tinfoilEventsHeaderValue(tinfoilEvents),
+           mergedHeaders[tinfoilEventsHeader] == nil {
+            mergedHeaders[tinfoilEventsHeader] = eventsHeader
+        }
+
         let configuration = OpenAI.Configuration(
             token: apiKey,
             host: urlComponents.host,
             port: urlComponents.port ?? defaultPort,
             scheme: urlComponents.scheme,
+            customHeaders: mergedHeaders,
             parsingOptions: parsingOptions
         )
 

--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -150,13 +150,6 @@ public class TinfoilAI {
         openAIClient.chatsStream(query: query)
     }
 
-    public func chatsStream(
-        query: ChatQuery,
-        onWebSearchEvent: @escaping @Sendable (WebSearchEvent) -> Void
-    ) -> AsyncThrowingStream<ChatStreamResult, Error> {
-        openAIClient.chatsStream(query: query, onWebSearchEvent: onWebSearchEvent)
-    }
-
     public func images(query: ImagesQuery) async throws -> ImagesResult {
         try await openAIClient.images(query: query)
     }

--- a/Sources/TinfoilAI/TinfoilEvent.swift
+++ b/Sources/TinfoilAI/TinfoilEvent.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Tinfoil-specific progress events the router can emit inline with the
+/// model's assistant text. Each case maps to one comma-separated value in
+/// the `X-Tinfoil-Events` request header. The router rides these events
+/// as `<tinfoil-event>...</tinfoil-event>` markers carried inside the
+/// normal content stream: strict OpenAI SDKs simply see the tags as text,
+/// while clients that opted in parse and strip the tags before rendering.
+public enum TinfoilEvent: String, Sendable, Hashable, CaseIterable {
+    /// Live progress updates for router-owned web search and URL fetch
+    /// tool calls. Each marker carries the same shape the non-streaming
+    /// `web_search_call` output item uses, with extra `status` values
+    /// (`blocked`) and an optional `error` object for detail beyond what
+    /// the OpenAI spec documents.
+    case webSearch = "web_search"
+}
+
+/// Name of the request header clients set to opt into the tinfoil-event
+/// marker stream.
+public let tinfoilEventsHeader = "X-Tinfoil-Events"
+
+/// Formats a set of tinfoil events as the comma-separated value expected
+/// by the `X-Tinfoil-Events` request header. Returns `nil` when the set
+/// is empty so callers can skip adding the header entirely.
+func tinfoilEventsHeaderValue(_ events: Set<TinfoilEvent>) -> String? {
+    guard !events.isEmpty else { return nil }
+    return events.map(\.rawValue).sorted().joined(separator: ",")
+}

--- a/Tests/TinfoilEventTests.swift
+++ b/Tests/TinfoilEventTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import TinfoilAI
+
+/// Pure-unit coverage for the TinfoilEvent header formatting helper. The
+/// integration tests in TinfoilAITests.swift exercise the full create()
+/// path, but those require live enclave verification and a network API
+/// key; this file pins the header contract in isolation.
+final class TinfoilEventTests: XCTestCase {
+
+    func testEmptyEventSetReturnsNilSoHeaderIsOmitted() {
+        let value = tinfoilEventsHeaderValue([])
+        XCTAssertNil(value, "An empty event set must return nil so callers skip adding the header entirely.")
+    }
+
+    func testSingleEventProducesSpecValue() {
+        let value = tinfoilEventsHeaderValue([.webSearch])
+        XCTAssertEqual(value, "web_search", "The header value must match the spec'd family name exactly.")
+    }
+
+    func testAllCasesAreSortedAlphabeticallyForStability() {
+        let value = tinfoilEventsHeaderValue(Set(TinfoilEvent.allCases))
+        let parts = (value ?? "").split(separator: ",").map(String.init)
+        XCTAssertEqual(parts, parts.sorted(), "Header families must be emitted in a stable order so router-side parsing is deterministic.")
+    }
+
+    func testHeaderNameMatchesRouterContract() {
+        XCTAssertEqual(tinfoilEventsHeader, "X-Tinfoil-Events", "The header name is part of the public contract with the router and must not drift without a coordinated release.")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for forwarding custom request headers and opt-in router progress events via the `X-Tinfoil-Events` header. Also fixes case-insensitive detection to prevent duplicate event headers when callers already set one.

- **New Features**
  - New `customHeaders` on `TinfoilAI.create(...)` to pass through extra request headers.
  - New `tinfoilEvents` to opt into progress events; sent as a comma-separated `X-Tinfoil-Events` header. Router emits `<tinfoil-event>...</tinfoil-event>` markers in the stream.
  - Added `TinfoilEvent` with `.webSearch` and a helper that formats the header; unit tests cover name and formatting.

- **Migration**
  - Removed `chatsStream(query:onWebSearchEvent:)`. Use `chatsStream(query:)` and, if opted in with `.webSearch`, parse and strip `<tinfoil-event>` markers from the stream.

<sup>Written for commit 981e8344701168a2f7c43beae9234d2feb13942e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

