### PR TITLE
chore: update ci runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `actions/checkout` to v5 in `release.yml` and `test.yml`. Keeps our macOS CI workflows on the latest supported action.

<sup>Written for commit 332b7caa9062e96f4860d02fc8037a7cd22c7759. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

