### PR TITLE
feat: re-export OpenAI symbols from TinfoilAI

### DIFF
--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OpenAI
+@_exported import OpenAI
 import EHBP
 
 /// Main entry point for the Tinfoil client library.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-export `OpenAI` symbols from `TinfoilAI` using `@_exported import`, so consumers get `OpenAI` APIs by importing `TinfoilAI` only.

- **Migration**
  - Remove direct `OpenAI` imports in files that already import `TinfoilAI`.

<sup>Written for commit 2c07b8a6854129fb7b9ba2609681091052316964. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

