### PR TITLE
chore: bump openai-swift-fork to 0.0.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.7"),
+        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.8"),
         .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.2.0"),
     ],
     targets: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `openai-swift-fork` from 0.0.7 to 0.0.8 in `Package.swift` to keep the dependency current and aligned with the latest fork release.

<sup>Written for commit f69956c699dce332176d0336228499e10f235573. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

