### PR TITLE
Add support for JWT token refresh

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.8"),
+        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.9"),
         .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.2.0"),
     ],
     targets: [

--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -39,6 +39,7 @@ public class TinfoilAI {
     /// header to know where to forward requests.
     public static func create(
         apiKey: String? = nil,
+        apiKeyProvider: (@Sendable () -> String?)? = nil,
         baseURL: String? = nil,
         githubRepo: String = TinfoilConstants.defaultGithubRepo,
         attestationBundleURL: String? = nil,
@@ -47,8 +48,12 @@ public class TinfoilAI {
         tinfoilEvents: Set<TinfoilEvent> = [],
         onVerification: VerificationCallback? = nil
     ) async throws -> TinfoilAI {
-        let finalApiKey = apiKey ?? ProcessInfo.processInfo.environment["TINFOIL_API_KEY"]
-        guard let finalApiKey = finalApiKey else {
+        let staticApiKey = apiKey ?? ProcessInfo.processInfo.environment["TINFOIL_API_KEY"]
+        // Attestation itself does not use the API key; it only authorizes
+        // inference requests. Require that a bearer can be resolved either
+        // statically or via the dynamic provider, so a caller using a rotating
+        // token (e.g. a short-lived JWT) is not forced to pass a placeholder key.
+        guard staticApiKey != nil || apiKeyProvider != nil else {
             throw TinfoilError.missingAPIKey
         }
 
@@ -69,7 +74,8 @@ public class TinfoilAI {
             let finalBaseURL = baseURL ?? enclaveURL
 
             return try TinfoilAI(
-                apiKey: finalApiKey,
+                apiKey: staticApiKey,
+                apiKeyProvider: apiKeyProvider,
                 baseURL: finalBaseURL,
                 enclaveURL: enclaveURL,
                 hpkePublicKeyHex: groundTruth.hpkePublicKey,
@@ -85,7 +91,8 @@ public class TinfoilAI {
 
     /// Internal initializer that sets up the EHBP session and OpenAI client
     internal convenience init(
-        apiKey: String,
+        apiKey: String?,
+        apiKeyProvider: (@Sendable () -> String?)? = nil,
         baseURL: String,
         enclaveURL: String,
         hpkePublicKeyHex: String?,
@@ -124,6 +131,7 @@ public class TinfoilAI {
 
         let configuration = OpenAI.Configuration(
             token: apiKey,
+            tokenProvider: apiKeyProvider,
             host: urlComponents.host,
             port: urlComponents.port ?? defaultPort,
             scheme: urlComponents.scheme,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a dynamic `apiKeyProvider` to support JWT/token rotation, so clients can use short‑lived tokens without a static key. Wires the provider into the OpenAI client and updates dependency to support it.

- **New Features**
  - Add `apiKeyProvider: (@Sendable () -> String?)?` to `TinfoilAI.create` and internal init.
  - Allow either `apiKey` or `apiKeyProvider`; throw if both are missing.
  - Pass `tokenProvider` to `OpenAI.Configuration` for runtime token refresh.

- **Dependencies**
  - Bump `openai-swift-fork` to `0.0.9` for `tokenProvider` support.

<sup>Written for commit 9c4065079858c8344235fa44eced0f578599d9b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

