### PR TITLE
Chore: update verifier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Tinfoil",
-            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.12.10/Tinfoil.xcframework.zip",
-            checksum: "4321000a3b53469dd6910c61e0306be48f7fb9a7cbd09f9e0e2528fc7f11e857"),
+            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.13.2/Tinfoil.xcframework.zip",
+            checksum: "fae1127dbd30b8441c1afb606c317bff6006436f29d3be4962e48e07be31a81e"),
         .target(
             name: "TinfoilAI",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .binaryTarget(
             name: "Tinfoil",
             url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.13.2/Tinfoil.xcframework.zip",
-            checksum: "fae1127dbd30b8441c1afb606c317bff6006436f29d3be4962e48e07be31a81e"),
+            checksum: "ed3ad5b558ffa64971dcb5c4320db7d77a68ee980ce0760bf4f678b51bfe0e17"),
         .target(
             name: "TinfoilAI",
             dependencies: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the verifier by bumping the `Tinfoil` binary target to v0.13.2. Updated the xcframework URL and checksum in Package.swift to match the new release.

<sup>Written for commit 3c0e982d57a48cb00eec41be77b3b6d122c9c770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

