### PR TITLE
feat: provision user_cache_secret for per-user prompt cache scoping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,5 @@ jobs:
 
       - name: Run tests
         run: swift test
+        env:
+          TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -109,6 +109,39 @@ let client = try await TinfoilAI.create(
 )
 ```
 
+## Prompt Cache Scoping
+
+The inference router partitions its prompt cache per API identity, so your cached prompts are never observable by other tenants. Within your tenant, the SDK scopes caching further with a `user_cache_secret`: requests carrying the same secret share cached prompt prefixes, requests carrying different secrets cannot observe each other's cache timing. The secret never reaches the model — the router consumes it to derive the cache namespace and strips it from the request.
+
+By default the SDK generates a random secret and persists it at `~/.tinfoil/user_cache_secret` (mode `0600`, shared with the other Tinfoil SDKs on the same machine), so caching just works with per-machine scoping. You can control it explicitly:
+
+```swift
+// Pin the secret for this client (e.g. one stable value per end user)
+let client = try await TinfoilAI.create(
+    apiKey: "YOUR_API_KEY",
+    userCacheSecret: secret
+)
+
+// Or provision it via the environment
+//   TINFOIL_USER_CACHE_SECRET=<secret>   use this value
+//   TINFOIL_USER_CACHE_SECRET=           (set but empty) disable: tenant-wide caching
+
+// Servers that hold many end users' conversations should scope per request;
+// a field set here always wins over the client-level secret:
+let query = ChatQuery(
+    messages: [.user(.init(content: .string("Hello!")))],
+    model: "model-name",
+    extraBody: ["user_cache_secret": .string(perUserSecret)]
+)
+
+// Opt out entirely (tenant-wide caching, no file written)
+let optedOut = try await TinfoilAI.create(
+    apiKey: "YOUR_API_KEY",
+    userCacheSecret: ""
+)
+```
+
+If the secret cannot be persisted (no home directory, read-only filesystem), the SDK falls back to an in-memory secret, so cache continuity resets on every process restart. Containerized deployments should set `TINFOIL_USER_CACHE_SECRET` explicitly — one value per end user if requests are per-user, or empty to keep tenant-wide caching across replicas.
 
 ## Configuration Options
 
@@ -121,6 +154,7 @@ let client = try await TinfoilAI.create(
     enclaveURL: String? = nil,          // Custom enclave URL (auto-selects router if nil)
     githubRepo: String = "tinfoilsh/confidential-model-router", // GitHub repo for verification
     parsingOptions: ParsingOptions = .relaxed,  // OpenAI parsing options
+    userCacheSecret: String? = nil,             // Prompt cache scoping secret (see "Prompt Cache Scoping")
     onVerification: VerificationCallback? = nil // Verification callback
 )
 

--- a/Sources/TinfoilAI/EHBPURLSession.swift
+++ b/Sources/TinfoilAI/EHBPURLSession.swift
@@ -16,6 +16,7 @@ public final class EHBPURLSessionFactory: URLSessionFactory, @unchecked Sendable
     private let baseURL: String
     private let enclaveURL: String?
     private let publicKey: Data
+    private let userCacheSecret: String
 
     /// Creates an EHBP URLSession factory
     ///
@@ -23,10 +24,13 @@ public final class EHBPURLSessionFactory: URLSessionFactory, @unchecked Sendable
     ///   - baseURL: Base URL where requests are sent (e.g., proxy server or enclave directly)
     ///   - enclaveURL: URL of the verified enclave (added as header when different from baseURL)
     ///   - publicKey: Server's X25519 public key (32 bytes)
-    public init(baseURL: String, enclaveURL: String? = nil, publicKey: Data) {
+    ///   - userCacheSecret: Resolved prompt-cache scoping secret injected into
+    ///     eligible request bodies before encryption (empty disables injection)
+    public init(baseURL: String, enclaveURL: String? = nil, publicKey: Data, userCacheSecret: String = "") {
         self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
         self.enclaveURL = enclaveURL
         self.publicKey = publicKey
+        self.userCacheSecret = userCacheSecret
     }
 
     public func makeUrlSession(delegate: URLSessionDataDelegateProtocol) -> URLSessionProtocol {
@@ -34,6 +38,7 @@ public final class EHBPURLSessionFactory: URLSessionFactory, @unchecked Sendable
             baseURL: baseURL,
             enclaveURL: enclaveURL,
             publicKey: publicKey,
+            userCacheSecret: userCacheSecret,
             delegate: delegate
         )
     }
@@ -45,14 +50,16 @@ internal final class EHBPStreamingSession: URLSessionProtocol, @unchecked Sendab
     private let baseURL: String
     private let enclaveURL: String?
     private let publicKey: Data
+    private let userCacheSecret: String
     private weak var delegate: URLSessionDataDelegateProtocol?
     private var activeTasks: [ObjectIdentifier: EHBPStreamingDataTask] = [:]
     private let lock = NSLock()
 
-    init(baseURL: String, enclaveURL: String? = nil, publicKey: Data, delegate: URLSessionDataDelegateProtocol) {
+    init(baseURL: String, enclaveURL: String? = nil, publicKey: Data, userCacheSecret: String = "", delegate: URLSessionDataDelegateProtocol) {
         self.baseURL = baseURL
         self.enclaveURL = enclaveURL
         self.publicKey = publicKey
+        self.userCacheSecret = userCacheSecret
         self.delegate = delegate
     }
 
@@ -65,6 +72,7 @@ internal final class EHBPStreamingSession: URLSessionProtocol, @unchecked Sendab
             baseURL: baseURL,
             enclaveURL: enclaveURL,
             publicKey: publicKey,
+            userCacheSecret: userCacheSecret,
             delegate: delegate,
             session: self,
             completionHandler: completionHandler
@@ -150,6 +158,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
     private let baseURL: String
     private let enclaveURL: String?
     private let publicKey: Data
+    private let userCacheSecret: String
     private weak var delegate: URLSessionDataDelegateProtocol?
     private weak var session: EHBPStreamingSession?
     private let completionHandler: @Sendable (Data?, URLResponse?, Error?) -> Void
@@ -170,6 +179,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
         baseURL: String,
         enclaveURL: String? = nil,
         publicKey: Data,
+        userCacheSecret: String = "",
         delegate: URLSessionDataDelegateProtocol?,
         session: EHBPStreamingSession,
         completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
@@ -178,6 +188,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
         self.baseURL = baseURL
         self.enclaveURL = enclaveURL
         self.publicKey = publicKey
+        self.userCacheSecret = userCacheSecret
         self.delegate = delegate
         self.session = session
         self.completionHandler = completionHandler
@@ -228,11 +239,20 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
             }
             URLHelpers.addProxyHeaderIfNeeded(to: &headers, baseURL: baseURL, enclaveURL: enclaveURL)
 
+            // The user-cache-secret field is added here, before EHBP seals
+            // the body, so the secret only ever travels inside the encrypted
+            // channel to the verified enclave.
+            let body = UserCacheSecret.provision(
+                request: request,
+                headers: &headers,
+                clientSecret: userCacheSecret
+            )
+
             let (stream, response) = try await ehbpClient.requestStream(
                 method: method,
                 path: path,
                 headers: headers,
-                body: request.httpBody
+                body: body
             )
 
             delegate?.urlSession(
@@ -270,6 +290,7 @@ public final class EHBPURLSession: URLSessionProtocol, @unchecked Sendable {
     private let ehbpClient: EHBPClient
     private let baseURL: String
     private let enclaveURL: String?
+    private let userCacheSecret: String
 
     /// Creates an EHBP URLSession with the given server public key
     ///
@@ -277,11 +298,14 @@ public final class EHBPURLSession: URLSessionProtocol, @unchecked Sendable {
     ///   - baseURL: Base URL where requests are sent (e.g., proxy server or enclave directly)
     ///   - enclaveURL: URL of the verified enclave (added as header when different from baseURL)
     ///   - publicKey: Server's X25519 public key (32 bytes)
+    ///   - userCacheSecret: Resolved prompt-cache scoping secret injected into
+    ///     eligible request bodies before encryption (empty disables injection)
     ///   - session: Underlying URLSession to use (defaults to shared)
-    public init(baseURL: String, enclaveURL: String? = nil, publicKey: Data, session: URLSession = .shared) throws {
+    public init(baseURL: String, enclaveURL: String? = nil, publicKey: Data, userCacheSecret: String = "", session: URLSession = .shared) throws {
         self.ehbpClient = try EHBPClient(baseURL: baseURL, publicKey: publicKey, session: session)
         self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
         self.enclaveURL = enclaveURL
+        self.userCacheSecret = userCacheSecret
     }
 
     // MARK: - URLSessionProtocol
@@ -359,11 +383,20 @@ public final class EHBPURLSession: URLSessionProtocol, @unchecked Sendable {
         }
         URLHelpers.addProxyHeaderIfNeeded(to: &headers, baseURL: baseURL, enclaveURL: enclaveURL)
 
+        // The user-cache-secret field is added here, before EHBP seals the
+        // body, so the secret only ever travels inside the encrypted channel
+        // to the verified enclave.
+        let body = UserCacheSecret.provision(
+            request: request,
+            headers: &headers,
+            clientSecret: userCacheSecret
+        )
+
         let (data, response) = try await ehbpClient.request(
             method: method,
             path: path,
             headers: headers,
-            body: request.httpBody
+            body: body
         )
 
         return (data, response)

--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -30,6 +30,15 @@ public class TinfoilAI {
     ///     emits `<tinfoil-event>...</tinfoil-event>` markers inline with
     ///     the assistant text. Strict OpenAI SDKs render the markers as
     ///     text; callers parse and strip them before display.
+    ///   - userCacheSecret: Scopes the router's prompt cache. `nil` (the
+    ///     default) resolves the secret from `TINFOIL_USER_CACHE_SECRET` or a
+    ///     generated value persisted at `~/.tinfoil/user_cache_secret`; a
+    ///     non-empty string pins it (use one stable value per end user); an
+    ///     empty string disables provisioning entirely (tenant-wide caching).
+    ///     Servers holding many end users' conversations should instead set
+    ///     the `user_cache_secret` field per request (e.g. via
+    ///     `ChatQuery.extraBody`), which always wins over the client-level
+    ///     secret.
     ///   - onVerification: Optional callback for verification results
     /// - Returns: A TinfoilAI client configured for secure communication (use like OpenAI client)
     ///
@@ -46,6 +55,7 @@ public class TinfoilAI {
         parsingOptions: ParsingOptions = .relaxed,
         customHeaders: [String: String] = [:],
         tinfoilEvents: Set<TinfoilEvent> = [],
+        userCacheSecret: String? = nil,
         onVerification: VerificationCallback? = nil
     ) async throws -> TinfoilAI {
         let staticApiKey = apiKey ?? ProcessInfo.processInfo.environment["TINFOIL_API_KEY"]
@@ -81,7 +91,8 @@ public class TinfoilAI {
                 hpkePublicKeyHex: groundTruth.hpkePublicKey,
                 parsingOptions: parsingOptions,
                 customHeaders: customHeaders,
-                tinfoilEvents: tinfoilEvents
+                tinfoilEvents: tinfoilEvents,
+                userCacheSecret: UserCacheSecret.resolve(explicit: userCacheSecret)
             )
         } catch {
             onVerification?(verifier.verificationDocument)
@@ -89,7 +100,9 @@ public class TinfoilAI {
         }
     }
 
-    /// Internal initializer that sets up the EHBP session and OpenAI client
+    /// Internal initializer that sets up the EHBP session and OpenAI client.
+    /// `userCacheSecret` is the already-resolved prompt-cache scoping secret
+    /// (see `UserCacheSecret.resolve`); an empty string disables injection.
     internal convenience init(
         apiKey: String?,
         apiKeyProvider: (@Sendable () -> String?)? = nil,
@@ -98,7 +111,8 @@ public class TinfoilAI {
         hpkePublicKeyHex: String?,
         parsingOptions: ParsingOptions = .relaxed,
         customHeaders: [String: String] = [:],
-        tinfoilEvents: Set<TinfoilEvent> = []
+        tinfoilEvents: Set<TinfoilEvent> = [],
+        userCacheSecret: String = ""
     ) throws {
         guard let hpkeKeyHex = hpkePublicKeyHex, !hpkeKeyHex.isEmpty else {
             throw TinfoilError.invalidConfiguration("Server does not support EHBP (no HPKE public key)")
@@ -113,13 +127,15 @@ public class TinfoilAI {
         let ehbpSession = try EHBPURLSession(
             baseURL: baseURL,
             enclaveURL: enclaveURL,
-            publicKey: hpkePublicKey
+            publicKey: hpkePublicKey,
+            userCacheSecret: userCacheSecret
         )
 
         let ehbpStreamingFactory = EHBPURLSessionFactory(
             baseURL: baseURL,
             enclaveURL: enclaveURL,
-            publicKey: hpkePublicKey
+            publicKey: hpkePublicKey,
+            userCacheSecret: userCacheSecret
         )
 
         let defaultPort = urlComponents.scheme == "https" ? 443 : 80

--- a/Sources/TinfoilAI/UserCacheSecret.swift
+++ b/Sources/TinfoilAI/UserCacheSecret.swift
@@ -1,0 +1,392 @@
+import Foundation
+import Security
+
+/// Provisions the per-user prompt-cache secret defined by the secure prompt
+/// caching contract. The router derives the request's prefix-cache namespace
+/// from it: requests carrying the same secret (under the same API identity)
+/// share cached prompt prefixes, requests carrying different secrets cannot
+/// observe each other's cache timing. The secret itself is stripped by the
+/// router and never reaches the model.
+///
+/// Resolution order, mirroring the other Tinfoil clients:
+///
+///  1. an explicit per-request `user_cache_secret` field in the body (never
+///     overwritten here), e.g. set via `ChatQuery.extraBody`,
+///  2. the `userCacheSecret` parameter of `TinfoilAI.create`,
+///  3. the `TINFOIL_USER_CACHE_SECRET` environment variable,
+///  4. a generated secret persisted at `~/.tinfoil/user_cache_secret` (0600),
+///     shared with the other Tinfoil SDKs on the same machine.
+///
+/// Injection happens in the EHBP session, before the body is sealed, so the
+/// secret is only ever visible to the verified enclave.
+internal enum UserCacheSecret {
+    /// Router-only request-body field. A non-empty string scopes the prompt
+    /// cache to that secret; an absent or empty value leaves the request in
+    /// the tenant-wide namespace.
+    static let bodyField = "user_cache_secret"
+
+    /// Environment variable that provisions the secret. Setting it to an
+    /// empty string disables generation entirely (tenant-wide caching), which
+    /// is the right call for pooled multi-user deployments that would
+    /// otherwise mint a fresh namespace per container.
+    static let environmentVariable = "TINFOIL_USER_CACHE_SECRET"
+    private static let homeEnvironmentVariable = "HOME"
+
+    /// Persisted-secret path components under the home directory. The other
+    /// Tinfoil SDKs use the same file, so one machine gets one cache
+    /// namespace across tools.
+    static let directoryName = ".tinfoil"
+    static let fileName = "user_cache_secret"
+    private static let directoryMode: mode_t = 0o700
+    private static let secretFileMode: mode_t = 0o600
+
+    /// OpenAI-compatible endpoints whose bodies carry the field. Matched by
+    /// suffix with no `/v1` prefix required, so custom base URLs
+    /// (path-prefixed proxies or `/v1`-less roots) still qualify. Other
+    /// endpoints (embeddings, audio, files) are excluded: their engines do
+    /// not prefix-cache and may reject unknown fields.
+    static let eligiblePathSuffixes = [
+        "/chat/completions",
+        "/completions",
+        "/responses",
+    ]
+
+    // MARK: - Resolution
+
+    /// Resolves the client-level secret: the explicit `TinfoilAI.create`
+    /// parameter wins (`nil` means "not set"; an empty string disables
+    /// provisioning entirely), then the environment (where set-but-empty
+    /// also disables), then the persisted (or generated) secret. An empty
+    /// result means injection is disabled. Never throws: every failure
+    /// degrades to an in-memory secret or to tenant-wide caching.
+    static func resolve(
+        explicit: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL? = defaultHomeDirectory
+    ) -> String {
+        if let explicit {
+            return explicit
+        }
+        if let env = environment[environmentVariable] {
+            return env
+        }
+        return loadOrGenerate(homeDirectory: homeDirectory)
+    }
+
+    /// Home directory holding the persisted secret. Command-line processes
+    /// honor `$HOME`, matching the other Tinfoil SDKs, while iOS falls back
+    /// to the app container reported by `NSHomeDirectory()`.
+    static var defaultHomeDirectory: URL? {
+        homeDirectory()
+    }
+
+    static func homeDirectory(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fallback: String = NSHomeDirectory()
+    ) -> URL? {
+        let home = environment[homeEnvironmentVariable] ?? fallback
+        return home.isEmpty ? nil : URL(fileURLWithPath: home, isDirectory: true)
+    }
+
+    /// Returns a fresh 256-bit random secret, hex-encoded. Never falls back
+    /// to a weak generator: no secret means tenant-wide caching, which is
+    /// safe.
+    static func generate() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            return ""
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Process-lifetime fallback for when the secret cannot be persisted. An
+    /// unpersisted secret still isolates this process's cache namespace, but
+    /// continuity is lost on restart — like a session ID, it silently resets
+    /// the namespace every deploy.
+    private static let ephemeral = generate()
+
+    /// Returns the secret persisted under the home directory, generating and
+    /// persisting one on first use. When the home directory is unavailable or
+    /// unwritable it falls back to a process-lifetime in-memory secret.
+    static func loadOrGenerate(homeDirectory: URL?) -> String {
+        guard let homeDirectory else {
+            return ephemeral
+        }
+        let directory = homeDirectory.appendingPathComponent(directoryName, isDirectory: true)
+
+        var directoryStatus = stat()
+        if lstat(directory.path, &directoryStatus) == 0 {
+            guard directoryStatus.st_mode & S_IFMT == S_IFDIR else {
+                return ephemeral
+            }
+        } else {
+            guard errno == ENOENT else {
+                return ephemeral
+            }
+            do {
+                try FileManager.default.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: directoryMode]
+                )
+            } catch {
+                return ephemeral
+            }
+        }
+
+        let destination = directory.appendingPathComponent(fileName, isDirectory: false)
+        switch readPersistedSecret(at: destination) {
+        case .value(let existing):
+            return existing
+        case .failure, .invalid:
+            return ephemeral
+        case .absent:
+            break
+        }
+
+        let secret = generate()
+        if secret.isEmpty {
+            return ""
+        }
+
+        let candidate = directory.appendingPathComponent(
+            "\(fileName).\(getpid()).\(UUID().uuidString).tmp",
+            isDirectory: false
+        )
+        defer { _ = unlink(candidate.path) }
+        var candidateFD = openRetryingOnInterruption(
+            candidate.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW,
+            secretFileMode
+        )
+        guard candidateFD >= 0 else {
+            return ephemeral
+        }
+        defer {
+            if candidateFD >= 0 {
+                _ = close(candidateFD)
+            }
+        }
+
+        guard writeAll(Data(secret.utf8), to: candidateFD) else {
+            return ephemeral
+        }
+        guard close(candidateFD) == 0 else {
+            candidateFD = -1
+            return ephemeral
+        }
+        candidateFD = -1
+
+        let linkResult = linkRetryingOnInterruption(candidate.path, destination.path)
+        if linkResult == 0 {
+            return secret
+        }
+        guard errno == EEXIST else {
+            return ephemeral
+        }
+
+        switch readPersistedSecret(at: destination) {
+        case .value(let persisted):
+            return persisted
+        case .absent, .failure, .invalid:
+            return ephemeral
+        }
+    }
+
+    /// Reads the persisted secret, trimming surrounding whitespace (the file
+    /// may be hand-edited or written by another SDK with a trailing newline).
+    /// Blank and invalid UTF-8 files are unusable because language runtimes
+    /// do not normalize them consistently.
+    private enum PersistedSecret {
+        case value(String)
+        case absent
+        case invalid
+        case failure
+    }
+
+    private static func readPersistedSecret(at file: URL) -> PersistedSecret {
+        let fd = openRetryingOnInterruption(file.path, O_RDONLY | O_NOFOLLOW | O_NONBLOCK)
+        guard fd >= 0 else {
+            return errno == ENOENT ? .absent : .failure
+        }
+        defer { _ = close(fd) }
+
+        guard descriptorHasType(fd, type: S_IFREG) else {
+            return .failure
+        }
+        return readSecret(from: fd)
+    }
+
+    private static func readSecret(from fd: Int32) -> PersistedSecret {
+        guard lseek(fd, 0, SEEK_SET) >= 0 else {
+            return .failure
+        }
+        var contents = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBytes {
+                read(fd, $0.baseAddress, $0.count)
+            }
+            if count > 0 {
+                contents.append(buffer, count: count)
+            } else if count == 0 {
+                break
+            } else if errno != EINTR {
+                return .failure
+            }
+        }
+        guard let decoded = String(data: contents, encoding: .utf8) else {
+            return .invalid
+        }
+        let trimmed = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? .invalid : .value(trimmed)
+    }
+
+    private static func writeAll(_ contents: Data, to fd: Int32) -> Bool {
+        contents.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                return contents.isEmpty
+            }
+            var offset = 0
+            while offset < bytes.count {
+                let count = write(fd, baseAddress.advanced(by: offset), bytes.count - offset)
+                if count > 0 {
+                    offset += count
+                } else if count == 0 || errno != EINTR {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+
+    private static func openRetryingOnInterruption(
+        _ path: String,
+        _ flags: Int32,
+        _ mode: mode_t = 0
+    ) -> Int32 {
+        var fd: Int32
+        repeat {
+            fd = open(path, flags, mode)
+        } while fd < 0 && errno == EINTR
+        return fd
+    }
+
+    private static func descriptorHasType(
+        _ fd: Int32,
+        type: mode_t
+    ) -> Bool {
+        var status = stat()
+        return fstat(fd, &status) == 0
+            && status.st_mode & S_IFMT == type
+    }
+
+    private static func linkRetryingOnInterruption(_ source: String, _ destination: String) -> Int32 {
+        var result: Int32
+        repeat {
+            result = link(source, destination)
+        } while result != 0 && errno == EINTR
+        return result
+    }
+
+    // MARK: - Injection
+
+    /// Applies the client-level secret to an outgoing request, returning the
+    /// body to hand to the sealing client: the injected bytes when the
+    /// request is eligible, the caller's original bytes otherwise. When the
+    /// body changes, any Content-Length entry in `headers` is updated to
+    /// describe the injected bytes.
+    static func provision(
+        request: URLRequest,
+        headers: inout [String: String],
+        clientSecret: String
+    ) -> Data? {
+        guard !clientSecret.isEmpty,
+              let body = request.httpBody,
+              isEligible(method: request.httpMethod, path: request.url?.path ?? "", body: body),
+              let injected = inject(into: body, secret: clientSecret)
+        else {
+            return request.httpBody
+        }
+        for key in headers.keys where key.caseInsensitiveCompare("Content-Length") == .orderedSame {
+            headers[key] = String(injected.count)
+        }
+        return injected
+    }
+
+    /// Reports whether the request can carry the field: a POST with a body
+    /// to one of the supported endpoints.
+    static func isEligible(method: String?, path: String, body: Data?) -> Bool {
+        guard method?.uppercased() == "POST", let body, !body.isEmpty else {
+            return false
+        }
+        return eligiblePathSuffixes.contains { path.hasSuffix($0) }
+    }
+
+    /// Adds the field to a JSON-object body by splicing it in ahead of the
+    /// closing brace, leaving every caller-written byte — including number
+    /// formatting, which a float round-trip would corrupt — exactly as the
+    /// caller serialized it. Returns nil — forward the original bytes — for
+    /// non-object bodies, trailing data, or a body that already carries the
+    /// field: an explicit per-request value, including an explicit empty
+    /// string (= opt out for that request), always wins.
+    static func inject(into body: Data, secret: String) -> Data? {
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              !containsTrailingComma(in: body),
+              object[bodyField] == nil,
+              let field = try? JSONSerialization.data(withJSONObject: [bodyField: secret])
+        else {
+            return nil
+        }
+
+        // Splice the field in front of the closing brace, keeping the
+        // caller's trailing whitespace framing.
+        guard let closingBraceIndex = body.lastIndex(where: {
+            $0 != 0x20 && $0 != 0x09 && $0 != 0x0A && $0 != 0x0D
+        }), body[closingBraceIndex] == UInt8(ascii: "}") else {
+            return nil
+        }
+        var injected = Data(body[..<closingBraceIndex])
+        if !object.isEmpty {
+            injected.append(UInt8(ascii: ","))
+        }
+        injected.append(field.dropFirst().dropLast()) // strip the one-field object's own braces
+        injected.append(contentsOf: body[closingBraceIndex...])
+        return injected
+    }
+
+    /// `JSONSerialization` accepts trailing commas on some platforms even
+    /// though they are not valid JSON.
+    private static func containsTrailingComma(in body: Data) -> Bool {
+        let bytes = [UInt8](body)
+        var inString = false
+        var escaped = false
+        for index in bytes.indices {
+            let byte = bytes[index]
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if byte == UInt8(ascii: "\\") {
+                    escaped = true
+                } else if byte == UInt8(ascii: "\"") {
+                    inString = false
+                }
+            } else if byte == UInt8(ascii: "\"") {
+                inString = true
+            } else if byte == UInt8(ascii: "}") || byte == UInt8(ascii: "]") {
+                var previous = index
+                while previous > bytes.startIndex {
+                    previous -= 1
+                    let candidate = bytes[previous]
+                    if candidate == UInt8(ascii: ",") {
+                        return true
+                    }
+                    if candidate != 0x20 && candidate != 0x09 && candidate != 0x0A && candidate != 0x0D {
+                        break
+                    }
+                }
+            }
+        }
+        return false
+    }
+}

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -10,6 +10,7 @@ final class Box<T>: @unchecked Sendable {
 }
 
 final class TinfoilAITests: XCTestCase {
+    private static let testUserCacheSecret = "swift-live-integration-cache-secret"
 
     // MARK: - Test Configuration
 
@@ -41,10 +42,13 @@ final class TinfoilAITests: XCTestCase {
         XCTAssertEqual(try URLHelpers.parseURL("wss://enclave.example.com/realtime").scheme, "wss")
     }
 
-    func testClientSucceedsWhenVerificationSucceeds() async throws {
+    func testClientSucceedsWithCacheSecretWhenVerificationSucceeds() async throws {
         try skipIfNoAPIKey()
 
-        let client = try await TinfoilAI.create(apiKey: try getAPIKey())
+        let client = try await TinfoilAI.create(
+            apiKey: try getAPIKey(),
+            userCacheSecret: Self.testUserCacheSecret
+        )
 
         let chatQuery = ChatQuery(
             messages: [

--- a/Tests/UserCacheSecretTests.swift
+++ b/Tests/UserCacheSecretTests.swift
@@ -1,0 +1,689 @@
+import XCTest
+import Foundation
+import CryptoKit
+import EHBP
+import OpenAI
+@testable import TinfoilAI
+
+final class UserCacheSecretTests: XCTestCase {
+
+    private let envVar = UserCacheSecret.environmentVariable
+    private let promptResolutionTimeout: TimeInterval = 1
+
+    private final class StartGate: @unchecked Sendable {
+        private let condition = NSCondition()
+        private let participantCount: Int
+        private var waitingCount = 0
+        private var isOpen = false
+
+        init(participantCount: Int) {
+            self.participantCount = participantCount
+        }
+
+        func arriveAndWait() {
+            condition.lock()
+            waitingCount += 1
+            condition.broadcast()
+            while !isOpen {
+                condition.wait()
+            }
+            condition.unlock()
+        }
+
+        func releaseWhenReady() {
+            condition.lock()
+            while waitingCount < participantCount {
+                condition.wait()
+            }
+            isOpen = true
+            condition.broadcast()
+            condition.unlock()
+        }
+    }
+
+    /// Creates a throwaway home directory, removed on teardown.
+    private func makeTempHome() throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinfoil-ucs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: home) }
+        return home
+    }
+
+    private func secretFile(in home: URL) -> URL {
+        home.appendingPathComponent(UserCacheSecret.directoryName, isDirectory: true)
+            .appendingPathComponent(UserCacheSecret.fileName, isDirectory: false)
+    }
+
+    private func permissions(of file: URL) throws -> Int16 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+        return try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).int16Value
+    }
+
+    private func assertIsGeneratedSecret(_ secret: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(secret.count, 64, "expected a hex-encoded 256-bit secret", file: file, line: line)
+        XCTAssertEqual(secret, secret.lowercased(), "expected lowercase hex", file: file, line: line)
+        XCTAssertTrue(secret.allSatisfy { $0.isHexDigit }, "expected hex digits only", file: file, line: line)
+    }
+
+    private func resolvePromptly(
+        homeDirectory: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> String? {
+        let completion = expectation(description: "secret resolution completes")
+        let resultLock = NSLock()
+        var result: String?
+        DispatchQueue.global().async {
+            let resolved = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: homeDirectory)
+            resultLock.lock()
+            result = resolved
+            resultLock.unlock()
+            completion.fulfill()
+        }
+
+        guard XCTWaiter.wait(for: [completion], timeout: promptResolutionTimeout) == .completed else {
+            XCTFail("secret resolution blocked on a FIFO", file: file, line: line)
+            return nil
+        }
+        resultLock.lock()
+        defer { resultLock.unlock() }
+        return result
+    }
+
+    private func assertIsFIFO(_ fileURL: URL, file: StaticString = #filePath, line: UInt = #line) {
+        var status = stat()
+        XCTAssertEqual(lstat(fileURL.path, &status), 0, file: file, line: line)
+        XCTAssertEqual(status.st_mode & S_IFMT, S_IFIFO, file: file, line: line)
+    }
+
+    // MARK: - Resolution
+
+    func testHomeDirectoryHonorsEnvironment() throws {
+        let home = try makeTempHome()
+
+        XCTAssertEqual(
+            UserCacheSecret.homeDirectory(
+                environment: ["HOME": home.path],
+                fallback: NSHomeDirectory()
+            ),
+            home
+        )
+    }
+
+    func testExplicitSecretSetVersusUnset() throws {
+        let home = try makeTempHome()
+
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: "s1", environment: [:], homeDirectory: home),
+            "s1"
+        )
+
+        // An explicit empty secret must still count as "set": it disables
+        // provisioning instead of falling through to generation.
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: "", environment: [:], homeDirectory: home),
+            ""
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: secretFile(in: home).path),
+            "a disabled secret must not create the secret file"
+        )
+    }
+
+    func testResolvePrecedence() throws {
+        let home = try makeTempHome()
+
+        // Explicit option beats environment.
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: "explicit", environment: [envVar: "from-env"], homeDirectory: home),
+            "explicit"
+        )
+
+        // Explicit empty disables even with the environment set.
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: "", environment: [envVar: "from-env"], homeDirectory: home),
+            ""
+        )
+
+        // Environment beats generation and touches no file.
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: nil, environment: [envVar: "from-env"], homeDirectory: home),
+            "from-env"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: secretFile(in: home).path),
+            "an environment-provided secret must not create the secret file"
+        )
+
+        // Environment set but empty disables generation entirely: the right
+        // call for pooled multi-user deployments that would otherwise mint a
+        // fresh namespace per container.
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: nil, environment: [envVar: ""], homeDirectory: home),
+            ""
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: secretFile(in: home).path),
+            "a disabled secret must not create the secret file"
+        )
+    }
+
+    // MARK: - Persistence
+
+    func testGenerateAndPersist() throws {
+        let home = try makeTempHome()
+
+        let first = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home)
+        assertIsGeneratedSecret(first)
+
+        let file = secretFile(in: home)
+        let directory = file.deletingLastPathComponent()
+        XCTAssertEqual(try permissions(of: directory), 0o700, "the persistence directory must have mode 0700")
+        XCTAssertEqual(try permissions(of: file), 0o600, "the secret file must have mode 0600")
+
+        let persisted = try String(contentsOf: file, encoding: .utf8)
+        XCTAssertEqual(persisted, first, "the persisted contents must be the resolved secret")
+    }
+
+    func testConcurrentGenerationAdoptsSingleSecret() throws {
+        let home = try makeTempHome()
+        let callerCount = 32
+        let startGate = StartGate(participantCount: callerCount)
+        let completion = DispatchGroup()
+        let resultsLock = NSLock()
+        var results: [String] = []
+
+        for _ in 0..<callerCount {
+            completion.enter()
+            Thread.detachNewThread {
+                startGate.arriveAndWait()
+                let secret = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home)
+                resultsLock.lock()
+                results.append(secret)
+                resultsLock.unlock()
+                completion.leave()
+            }
+        }
+
+        startGate.releaseWhenReady()
+        completion.wait()
+
+        let first = try XCTUnwrap(results.first)
+        assertIsGeneratedSecret(first)
+        XCTAssertEqual(results.count, callerCount)
+        XCTAssertEqual(Set(results), [first], "all concurrent callers must adopt one secret")
+        XCTAssertEqual(
+            try String(contentsOf: secretFile(in: home), encoding: .utf8),
+            first,
+            "the persisted secret must match every caller's result"
+        )
+    }
+
+    func testAdoptsExistingFile() throws {
+        let home = try makeTempHome()
+        let file = secretFile(in: home)
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        // Trailing newline: the file may be hand-edited or written by another SDK.
+        try Data("shared-secret\n".utf8).write(to: file)
+
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home),
+            "shared-secret"
+        )
+    }
+
+    func testAdoptsPermissiveExistingStateWithoutChangingModes() throws {
+        let home = try makeTempHome()
+        let file = secretFile(in: home)
+        let directory = file.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o777]
+        )
+        try Data("shared-secret".utf8).write(to: file)
+        try FileManager.default.setAttributes([.posixPermissions: 0o777], ofItemAtPath: directory.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o666], ofItemAtPath: file.path)
+
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home),
+            "shared-secret"
+        )
+        XCTAssertEqual(try permissions(of: directory), 0o777)
+        XCTAssertEqual(try permissions(of: file), 0o666)
+    }
+
+    func testRejectsNonUTF8FileWithoutRewriting() throws {
+        let home = try makeTempHome()
+        let file = secretFile(in: home)
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let corrupted = Data([0xFF, 0xFE] + Array("abc".utf8))
+        try corrupted.write(to: file)
+
+        let secret = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home)
+        XCTAssertEqual(secret, UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: nil))
+        XCTAssertEqual(
+            try Data(contentsOf: file),
+            corrupted,
+            "invalid persistence state must not be rewritten"
+        )
+    }
+
+    func testRejectsBlankFileWithoutRewriting() throws {
+        let home = try makeTempHome()
+        let file = secretFile(in: home)
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try Data("  \n".utf8).write(to: file)
+
+        let secret = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home)
+        XCTAssertEqual(secret, UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: nil))
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), "  \n")
+    }
+
+    func testRejectsSymlinkSecretWithoutChangingTarget() throws {
+        let home = try makeTempHome()
+        let file = secretFile(in: home)
+        let target = home.appendingPathComponent("target", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try Data("target-secret".utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(at: file, withDestinationURL: target)
+
+        let secret = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home)
+
+        XCTAssertEqual(secret, UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: nil))
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "target-secret")
+        XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: file.path), target.path)
+    }
+
+    func testRejectsFIFOSecretWithoutBlocking() throws {
+        let home = try makeTempHome()
+        let file = secretFile(in: home)
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        XCTAssertEqual(mkfifo(file.path, 0o600), 0)
+
+        XCTAssertEqual(
+            resolvePromptly(homeDirectory: home),
+            UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: nil)
+        )
+        assertIsFIFO(file)
+    }
+
+    func testRejectsSymlinkPersistenceDirectoryWithoutChangingTarget() throws {
+        let home = try makeTempHome()
+        let target = home.appendingPathComponent("target", isDirectory: true)
+        let directory = secretFile(in: home).deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: target,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o755]
+        )
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: target.path)
+        try FileManager.default.createSymbolicLink(at: directory, withDestinationURL: target)
+
+        let secret = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: home)
+
+        assertIsGeneratedSecret(secret)
+        XCTAssertEqual(try permissions(of: target), 0o755)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: target.appendingPathComponent(UserCacheSecret.fileName).path)
+        )
+    }
+
+    func testFallsBackWithoutHome() {
+        let first = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: nil)
+        XCTAssertFalse(first.isEmpty, "no home directory must still yield a process-lifetime secret")
+        XCTAssertEqual(
+            UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: nil),
+            first,
+            "the in-memory fallback must be stable within the process"
+        )
+    }
+
+    func testFallsBackWhenHomeNotADirectory() throws {
+        let parent = try makeTempHome()
+        let notADirectory = parent.appendingPathComponent("not-a-dir", isDirectory: false)
+        try Data("x".utf8).write(to: notADirectory)
+
+        let secret = UserCacheSecret.resolve(explicit: nil, environment: [:], homeDirectory: notADirectory)
+        XCTAssertFalse(secret.isEmpty, "an unwritable home must still yield a process-lifetime secret")
+    }
+
+    // MARK: - Injection
+
+    private func postRequest(path: String, body: String?) -> URLRequest {
+        var request = URLRequest(url: URL(string: "https://enclave.example.com\(path)")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let body {
+            request.httpBody = Data(body.utf8)
+        }
+        return request
+    }
+
+    func testInjectsOnEligiblePaths() throws {
+        let paths = [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/responses",
+            "/api/v1/chat/completions", // proxy base URL with a path prefix
+            "/chat/completions", // custom base URL without a /v1 root
+        ]
+        for path in paths {
+            let raw = #"{"model":"m"}"#
+            let request = postRequest(path: path, body: raw)
+            var headers = ["Content-Type": "application/json", "Content-Length": String(raw.utf8.count)]
+
+            let body = try XCTUnwrap(
+                UserCacheSecret.provision(request: request, headers: &headers, clientSecret: "s1"),
+                "expected a body for \(path)"
+            )
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(object["model"] as? String, "m")
+            XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, "s1", "expected injection on \(path)")
+
+            // Length metadata must describe the injected bytes: the sealing
+            // client frames and encrypts exactly what we hand it, so a stale
+            // Content-Length would describe a body that no longer exists.
+            XCTAssertEqual(headers["Content-Length"], String(body.count))
+        }
+    }
+
+    func testSkipsIneligibleRequests() throws {
+        // Non-allowlisted endpoints forward the body byte-identical.
+        let raw = #"{"model":"m","input":"text"}"#
+        var headers: [String: String] = [:]
+        for path in ["/v1/embeddings", "/embeddings"] {
+            let embeddings = postRequest(path: path, body: raw)
+            XCTAssertEqual(
+                UserCacheSecret.provision(request: embeddings, headers: &headers, clientSecret: "s1"),
+                Data(raw.utf8),
+                "expected no injection on \(path)"
+            )
+        }
+
+        // GET with no body is forwarded as-is.
+        var get = URLRequest(url: URL(string: "https://enclave.example.com/v1/models")!)
+        get.httpMethod = "GET"
+        XCTAssertNil(UserCacheSecret.provision(request: get, headers: &headers, clientSecret: "s1"))
+
+        // An empty client-level secret disables injection.
+        let chat = postRequest(path: "/v1/chat/completions", body: #"{"model":"m"}"#)
+        XCTAssertEqual(
+            UserCacheSecret.provision(request: chat, headers: &headers, clientSecret: ""),
+            Data(#"{"model":"m"}"#.utf8)
+        )
+    }
+
+    func testNeverClobbersExistingField() {
+        let bodies = [
+            #"{"model":"m","user_cache_secret":"end-user-7"}"#,        // explicit per-request secret
+            #"{"model":"m","user_cache_secret":""}"#,                  // explicit empty opt-out
+            #"{"model":"m","user_cache_secre\u0074":"end-user-7"}"#, // escaped spelling of the same key
+        ]
+        for raw in bodies {
+            let request = postRequest(path: "/v1/chat/completions", body: raw)
+            var headers: [String: String] = [:]
+            XCTAssertEqual(
+                UserCacheSecret.provision(request: request, headers: &headers, clientSecret: "client-level"),
+                Data(raw.utf8),
+                "a body that already carries the field must pass through byte-identical"
+            )
+        }
+    }
+
+    func testNonObjectBodiesForwardedUntouched() {
+        // The trailing '}' / ']' cases matter: a parser that stops at the
+        // first complete object would re-serialize the body with the trailing
+        // bytes silently dropped, turning a request the server rejects into
+        // one it accepts.
+        let bodies = [
+            "not json",
+            "[1,2,3]",
+            "null",
+            #"{"model":"m"} trailing"#,
+            #"{"model":"m"}}"#,
+            #"{"model":"m"}]"#,
+            #"{"model":"m"}} garbage"#,
+            // Malformed variants the structural scan must reject too.
+            "{",
+            #"{"a":}"#,
+            #"{"a":1,}"#,
+            #"{"a" "b"}"#,
+            #"{"a":01}"#,
+            #"{"a":truey}"#,
+            #"{"a":"unterminated"#,
+        ]
+        for raw in bodies {
+            let request = postRequest(path: "/v1/chat/completions", body: raw)
+            var headers: [String: String] = [:]
+            XCTAssertEqual(
+                UserCacheSecret.provision(request: request, headers: &headers, clientSecret: "s1"),
+                Data(raw.utf8),
+                "bodies the router-side schema would reject must be forwarded untouched: \(raw)"
+            )
+        }
+    }
+
+    func testInvalidUTF8BodyForwardedUntouched() {
+        let raw = Data([0x7B, 0x22, 0x78, 0x22, 0x3A, 0x22, 0xFF, 0x22, 0x7D])
+        var request = URLRequest(url: URL(string: "https://enclave.example.com/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.httpBody = raw
+        var headers: [String: String] = [:]
+
+        XCTAssertEqual(
+            UserCacheSecret.provision(request: request, headers: &headers, clientSecret: "s1"),
+            raw
+        )
+    }
+
+    func testAllowsTrailingWhitespace() throws {
+        // Trailing whitespace is not trailing data: strict JSON parsers
+        // accept it, so the injection must too — clients routinely end
+        // bodies with \n.
+        let request = postRequest(path: "/v1/chat/completions", body: "{\"model\":\"m\"}\n\t ")
+        var headers: [String: String] = [:]
+        let body = try XCTUnwrap(UserCacheSecret.provision(request: request, headers: &headers, clientSecret: "s1"))
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, "s1")
+        XCTAssertTrue(
+            String(decoding: body, as: UTF8.self).hasSuffix("}\n\t "),
+            "the caller's whitespace framing must be preserved"
+        )
+    }
+
+    func testPreservesNumberPrecision() throws {
+        // 2^53+1 is not representable as a Double; a decode/re-encode cycle
+        // that goes through floating point would corrupt it.
+        let request = postRequest(path: "/v1/chat/completions", body: #"{"model":"m","seed":9007199254740993}"#)
+        var headers: [String: String] = [:]
+        let body = try XCTUnwrap(UserCacheSecret.provision(request: request, headers: &headers, clientSecret: "s1"))
+
+        let text = String(decoding: body, as: UTF8.self)
+        XCTAssertTrue(text.contains(#""seed":9007199254740993"#), "seed must survive injection intact: \(text)")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, "s1")
+    }
+
+    func testEscapesSecretWhenSplicing() throws {
+        // A caller-supplied secret is spliced into JSON source text, so any
+        // JSON-significant characters in it must be escaped.
+        let hostile = #"s1"},"x":"\"#
+        let injected = try XCTUnwrap(UserCacheSecret.inject(into: Data(#"{"model":"m"}"#.utf8), secret: hostile))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: injected) as? [String: Any])
+        XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, hostile)
+        XCTAssertEqual(object.count, 2)
+    }
+
+    func testInjectsIntoEmptyObject() throws {
+        let injected = try XCTUnwrap(UserCacheSecret.inject(into: Data("{}".utf8), secret: "s1"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: injected) as? [String: Any])
+        XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, "s1")
+        XCTAssertEqual(object.count, 1)
+    }
+
+    func testUnsupportedJSONForwardedUntouched() {
+        let depth = 600
+        let bodies = [
+            #"{"model":"m","x":1e999}"#,
+            #"{"model":"m","a":"#
+                + String(repeating: #"{"n":"#, count: depth)
+                + "1"
+                + String(repeating: "}", count: depth)
+                + "}",
+        ]
+        for raw in bodies {
+            let request = postRequest(path: "/v1/chat/completions", body: raw)
+            var headers: [String: String] = [:]
+            XCTAssertEqual(
+                UserCacheSecret.provision(request: request, headers: &headers, clientSecret: "s1"),
+                Data(raw.utf8)
+            )
+        }
+    }
+
+    func testBracesInsideStringsDoNotConfuseInjection() throws {
+        let raw = #"{"a":"} \" { not the end","b":[1,2]}"#
+        let injected = try XCTUnwrap(UserCacheSecret.inject(into: Data(raw.utf8), secret: "s1"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: injected) as? [String: Any])
+        XCTAssertEqual(object["a"] as? String, #"} " { not the end"#)
+        XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, "s1")
+        XCTAssertEqual(object.count, 3)
+    }
+
+    // MARK: - End to end through the real client machinery
+
+    /// Drives the real TinfoilAI client (OpenAI SDK -> EHBP session) against
+    /// a local server holding the matching HPKE private key, pinning that the
+    /// client-level secret rides inside the sealed body exactly as the SDK
+    /// builds it — and that a per-request field set via `ChatQuery.extraBody`
+    /// wins over the client-level secret.
+    func testEndToEndThroughTinfoilClient() async throws {
+        let privateKey = Curve25519.KeyAgreement.PrivateKey()
+        let server = LocalTestServer()
+        server.responseBody = {
+            // A zero-length chunk: enough for EHBP response framing; the
+            // OpenAI decode then fails, which the test tolerates.
+            var data = Data()
+            var length = UInt32(0).bigEndian
+            data.append(Data(bytes: &length, count: 4))
+            return data
+        }()
+        try server.start()
+        defer { server.stop() }
+
+        let client = try TinfoilAI(
+            apiKey: "test-api-key",
+            baseURL: server.baseURL,
+            enclaveURL: server.baseURL,
+            hpkePublicKeyHex: privateKey.publicKey.rawRepresentation.hexString,
+            userCacheSecret: "client-level"
+        )
+
+        // The client-level secret arrives inside the encrypted body.
+        let query = ChatQuery(
+            messages: [.user(.init(content: .string("hi")))],
+            model: "m"
+        )
+        do { _ = try await client.chats(query: query) } catch {
+            // Expected: the mock response is not a valid chat completion.
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        var body = try decryptedRequestBody(from: server, privateKey: privateKey)
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(server.requestStore.lastRequest?.path, "/v1/chat/completions")
+        XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, "client-level")
+        XCTAssertEqual(object["model"] as? String, "m")
+
+        // The streaming session seals the same injected body.
+        server.requestStore.clear()
+        let streamQuery = ChatQuery(
+            messages: [.user(.init(content: .string("hi")))],
+            model: "m",
+            stream: true
+        )
+        do {
+            for try await _ in client.chatsStream(query: streamQuery) {}
+        } catch {
+            // Expected: the mock response carries no usable chunks.
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        body = try decryptedRequestBody(from: server, privateKey: privateKey)
+        object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object[UserCacheSecret.bodyField] as? String, "client-level")
+
+        // A per-request field set through the public API wins over the
+        // client-level secret.
+        server.requestStore.clear()
+        let overrideQuery = ChatQuery(
+            messages: [.user(.init(content: .string("hi")))],
+            model: "m",
+            extraBody: [UserCacheSecret.bodyField: .string("end-user-7")]
+        )
+        do { _ = try await client.chats(query: overrideQuery) } catch {
+            // Expected: the mock response is not a valid chat completion.
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        body = try decryptedRequestBody(from: server, privateKey: privateKey)
+        object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(
+            object[UserCacheSecret.bodyField] as? String,
+            "end-user-7",
+            "a per-request field must win over the client-level secret"
+        )
+    }
+
+    /// Decrypts the last captured EHBP request body with the server's HPKE
+    /// private key, proving the injected field sits inside the sealed body.
+    private func decryptedRequestBody(
+        from server: LocalTestServer,
+        privateKey: Curve25519.KeyAgreement.PrivateKey
+    ) throws -> Data {
+        let request = try XCTUnwrap(server.requestStore.lastRequest, "no request was captured")
+        let encapsulatedHex = try XCTUnwrap(
+            request.headers[EHBPProtocol.encapsulatedKeyHeader],
+            "request must carry the EHBP encapsulated key"
+        )
+        let encapsulatedKey = try XCTUnwrap(Data(hexString: encapsulatedHex))
+        let framed = [UInt8](try XCTUnwrap(request.body, "no request body was captured"))
+
+        // Request framing: LEN (4 bytes big-endian) || ciphertext.
+        XCTAssertGreaterThan(framed.count, 4)
+        let length = Int(framed[0]) << 24 | Int(framed[1]) << 16 | Int(framed[2]) << 8 | Int(framed[3])
+        XCTAssertEqual(framed.count, 4 + length, "body must be a single framed chunk")
+        let ciphertext = Data(framed[4...])
+
+        var recipient = try HPKE.Recipient(
+            privateKey: privateKey,
+            ciphersuite: HPKE.Ciphersuite(kem: .Curve25519_HKDF_SHA256, kdf: .HKDF_SHA256, aead: .AES_GCM_256),
+            info: Data(EHBPConstants.hpkeRequestInfo.utf8),
+            encapsulatedKey: encapsulatedKey
+        )
+        return try recipient.open(ciphertext)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds per-user prompt cache scoping. The SDK provisions and injects a `user_cache_secret` before HPKE sealing, with `userCacheSecret` on `TinfoilAI.create` and a default persisted at `~/.tinfoil/user_cache_secret`.

- **New Features**
  - Secret resolution: body `user_cache_secret` (wins) > `userCacheSecret` in `TinfoilAI.create` > `TINFOIL_USER_CACHE_SECRET` (empty disables) > generated 32‑byte hex at `~/.tinfoil/user_cache_secret` (env/explicit are never written).
  - Injection: POST JSON bodies to `/chat/completions`, `/completions`, `/responses` (with or without `/v1`); updates `Content-Length`; never overwrites an existing field; forwards non‑object/malformed or invalid UTF‑8 bodies unchanged; byte‑preserving splice; JSON‑escaped; runs pre‑HPKE in both regular and streaming paths. API/Docs: `userCacheSecret` on `TinfoilAI.create`; README adds “Prompt Cache Scoping” with per‑request override via `extraBody` and how to opt out with an empty secret or `TINFOIL_USER_CACHE_SECRET=`.

- **Bug Fixes**
  - Persistence and safety: concurrent init adopts a single persisted secret; directory/file modes `0700`/`0600`; respects `HOME`; ignores symlinks/FIFOs and unwritable or missing homes; falls back to a process‑lifetime in‑memory secret. Validation: invalid/blank persisted files are rejected without rewriting.

<sup>Written for commit 55c08e2919b25b51b2bbddfb84dfdc846be7b837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

