### PR TITLE
chore: bump verifier to v0.14.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Tinfoil",
-            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.13.2/Tinfoil.xcframework.zip",
-            checksum: "ed3ad5b558ffa64971dcb5c4320db7d77a68ee980ce0760bf4f678b51bfe0e17"),
+            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.14.1/Tinfoil.xcframework.zip",
+            checksum: "f0593c66783476a5458af0d75a778363d6995f5a9a324c479ca33b3aef73c1d0"),
         .target(
             name: "TinfoilAI",
             dependencies: [


### PR DESCRIPTION
Picks up the updated MR_SEAM whitelist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `Tinfoil` verifier to v0.14.1 to pick up the updated MR_SEAM whitelist. Updates the binary target URL and checksum in Package.swift.

<sup>Written for commit 928d5a8e7ac08f4e72597f93f500e3eafeb8937e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

