### PR TITLE
fix: validate HTTP API URLs

### DIFF
--- a/Sources/TinfoilAI/Tinfoil.swift
+++ b/Sources/TinfoilAI/Tinfoil.swift
@@ -108,6 +108,8 @@ public class TinfoilAI {
             throw TinfoilError.invalidConfiguration("Invalid HPKE public key format (expected 32 bytes)")
         }
 
+        let urlComponents = try URLHelpers.parseHTTPURL(baseURL)
+
         let ehbpSession = try EHBPURLSession(
             baseURL: baseURL,
             enclaveURL: enclaveURL,
@@ -120,7 +122,6 @@ public class TinfoilAI {
             publicKey: hpkePublicKey
         )
 
-        let urlComponents = try URLHelpers.parseURL(baseURL)
         let defaultPort = urlComponents.scheme == "https" ? 443 : 80
 
         var mergedHeaders = customHeaders

--- a/Sources/TinfoilAI/URLHelpers.swift
+++ b/Sources/TinfoilAI/URLHelpers.swift
@@ -2,10 +2,26 @@ import Foundation
 
 /// Helper functions for URL handling
 internal enum URLHelpers {
+    private static func hasSchemeWithoutAuthority(_ urlString: String) -> Bool {
+        guard let separator = urlString.firstIndex(of: ":") else { return false }
+        let candidate = urlString[..<separator]
+        guard candidate.first?.isLetter == true,
+              candidate.allSatisfy({ $0.isLetter || $0.isNumber || "+-.".contains($0) }) else {
+            return false
+        }
+
+        let remainder = urlString[urlString.index(after: separator)...]
+        let port = remainder.prefix(while: \.isNumber)
+        let suffix = remainder.dropFirst(port.count)
+        let hasValidPortSuffix = suffix.first.map { "/?#".contains($0) } ?? true
+        let isHostPort = !port.isEmpty && hasValidPortSuffix
+        return !isHostPort
+    }
+
     /// Normalizes a URL string by adding https:// prefix if no protocol is specified
     static func normalizeURL(_ urlString: String) -> String {
         // Check if the URL already has a protocol
-        if urlString.contains("://") {
+        if urlString.contains("://") || hasSchemeWithoutAuthority(urlString) {
             return urlString
         }
         // Add https:// prefix if no protocol is present
@@ -26,10 +42,21 @@ internal enum URLHelpers {
                           userInfo: [NSLocalizedDescriptionKey: "Invalid URL: \(urlString)"])
         }
         
-        let scheme = url.scheme ?? "https"
+        let scheme = url.scheme?.lowercased() ?? "https"
         let port = url.port
         
         return (url: url, host: host, scheme: scheme, port: port)
+    }
+
+    /// Parses an HTTP API URL and requires the http or https scheme.
+    static func parseHTTPURL(_ urlString: String) throws -> (url: URL, host: String, scheme: String, port: Int?) {
+        let components = try parseURL(urlString)
+        guard components.scheme == "http" || components.scheme == "https" else {
+            throw NSError(domain: TinfoilConstants.urlHelpersErrorDomain,
+                          code: TinfoilConstants.invalidURLErrorCode,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP(S) URL: \(urlString)"])
+        }
+        return components
     }
     
     /// Builds a host string with port if needed

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -23,6 +23,24 @@ final class TinfoilAITests: XCTestCase {
         }
     }
 
+    func testURLHelpersAcceptHTTPAndHTTPSURLs() throws {
+        XCTAssertEqual(try URLHelpers.parseHTTPURL("http://localhost:8080/v1").scheme, "http")
+        XCTAssertEqual(try URLHelpers.parseHTTPURL("https://proxy.example.com/v1").scheme, "https")
+        XCTAssertEqual(try URLHelpers.parseHTTPURL("proxy.example.com/v1").scheme, "https")
+        XCTAssertEqual(try URLHelpers.parseHTTPURL("localhost:8080/v1").port, 8080)
+    }
+
+    func testURLHelpersRejectUnsupportedAndMalformedURLs() {
+        XCTAssertThrowsError(try URLHelpers.parseHTTPURL("ftp://proxy.example.com/v1"))
+        XCTAssertThrowsError(try URLHelpers.parseHTTPURL("mailto:user@example.com"))
+        XCTAssertThrowsError(try URLHelpers.parseHTTPURL("file:/tmp/test"))
+        XCTAssertThrowsError(try URLHelpers.parseHTTPURL("://"))
+    }
+
+    func testGenericURLParserDoesNotRestrictSchemes() throws {
+        XCTAssertEqual(try URLHelpers.parseURL("wss://enclave.example.com/realtime").scheme, "wss")
+    }
+
     func testClientSucceedsWhenVerificationSucceeds() async throws {
         try skipIfNoAPIKey()
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate and enforce HTTP(S) base URLs for the proxy to align with transport requirements. This prevents misconfiguration by rejecting non-HTTP schemes while keeping the generic parser scheme-agnostic.

- **Bug Fixes**
  - `TinfoilAI`: require HTTP(S) by switching to `URLHelpers.parseHTTPURL` for `baseURL`; compute default port from scheme.
  - `URLHelpers`: add `parseHTTPURL` (allows only http/https); improve `normalizeURL` to detect schemes without authority; lowercase scheme in `parseURL`.
  - Tests: add acceptance/rejection cases for URLs; confirm `parseURL` still accepts `wss` for enclave endpoints.

<sup>Written for commit db6548cbb3f7044b7d9c67d22ed47ebcf9fe9aee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

