### PR TITLE
perf: stop buffering streamed responses that are never read

### DIFF
--- a/Sources/TinfoilAI/EHBPURLSession.swift
+++ b/Sources/TinfoilAI/EHBPURLSession.swift
@@ -67,6 +67,21 @@ internal final class EHBPStreamingSession: URLSessionProtocol, @unchecked Sendab
         with request: URLRequest,
         completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
     ) -> URLSessionDataTaskProtocol {
+        return makeTask(with: request, accumulatesResponse: true, completionHandler: completionHandler)
+    }
+
+    public func dataTask(with request: URLRequest) -> URLSessionDataTaskProtocol {
+        // Delegate-driven streaming path (used by the OpenAI SDK): chunks are
+        // forwarded as they arrive and nobody reads the completion data, so
+        // the task skips buffering the full response.
+        return makeTask(with: request, accumulatesResponse: false) { _, _, _ in }
+    }
+
+    private func makeTask(
+        with request: URLRequest,
+        accumulatesResponse: Bool,
+        completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
+    ) -> EHBPStreamingDataTask {
         let task = EHBPStreamingDataTask(
             request: request,
             baseURL: baseURL,
@@ -75,16 +90,13 @@ internal final class EHBPStreamingSession: URLSessionProtocol, @unchecked Sendab
             userCacheSecret: userCacheSecret,
             delegate: delegate,
             session: self,
+            accumulatesResponse: accumulatesResponse,
             completionHandler: completionHandler
         )
         lock.lock()
         activeTasks[ObjectIdentifier(task)] = task
         lock.unlock()
         return task
-    }
-
-    public func dataTask(with request: URLRequest) -> URLSessionDataTaskProtocol {
-        return dataTask(with: request) { _, _, _ in }
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -161,6 +173,11 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
     private let userCacheSecret: String
     private weak var delegate: URLSessionDataDelegateProtocol?
     private weak var session: EHBPStreamingSession?
+    /// Whether the full decrypted response is buffered for the completion
+    /// handler. The delegate-driven streaming path disables this because its
+    /// completion handler discards the data, so buffering would only double
+    /// peak memory for large responses.
+    let accumulatesResponse: Bool
     private let completionHandler: @Sendable (Data?, URLResponse?, Error?) -> Void
 
     private var underlyingTask: Task<Void, Never>?
@@ -182,6 +199,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
         userCacheSecret: String = "",
         delegate: URLSessionDataDelegateProtocol?,
         session: EHBPStreamingSession,
+        accumulatesResponse: Bool = true,
         completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
     ) {
         self.request = request
@@ -191,6 +209,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
         self.userCacheSecret = userCacheSecret
         self.delegate = delegate
         self.session = session
+        self.accumulatesResponse = accumulatesResponse
         self.completionHandler = completionHandler
         self._originalRequest = request
     }
@@ -268,7 +287,9 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
             var accumulatedData = Data()
             for try await chunk in stream {
                 if Task.isCancelled { break }
-                accumulatedData.append(chunk)
+                if accumulatesResponse {
+                    accumulatedData.append(chunk)
+                }
                 delegate?.urlSession(session, dataTask: self, didReceive: chunk)
             }
 

--- a/Tests/EHBPTests.swift
+++ b/Tests/EHBPTests.swift
@@ -598,6 +598,32 @@ final class EHBPTests: XCTestCase {
         }
     }
 
+    func testStreamingSessionOnlyBuffersResponsesForCompletionHandlers() throws {
+        let delegate = NoopStreamingDelegate()
+        let session = EHBPStreamingSession(
+            baseURL: server.baseURL,
+            publicKey: testPublicKey,
+            delegate: delegate
+        )
+        let request = URLRequest(url: URL(string: "\(server.baseURL)/v1/chat/completions")!)
+
+        let delegateDrivenTask = try XCTUnwrap(
+            session.dataTask(with: request) as? EHBPStreamingDataTask
+        )
+        let completionHandlerTask = try XCTUnwrap(
+            session.dataTask(with: request) { _, _, _ in } as? EHBPStreamingDataTask
+        )
+
+        XCTAssertFalse(
+            delegateDrivenTask.accumulatesResponse,
+            "Delegate-driven streaming tasks should not buffer the full response"
+        )
+        XCTAssertTrue(
+            completionHandlerTask.accumulatesResponse,
+            "Completion-handler tasks must buffer the response they deliver"
+        )
+    }
+
     // MARK: - Protocol Constants Tests
 
     func testEHBPProtocolConstants() {
@@ -1785,6 +1811,28 @@ final class EHBPTests: XCTestCase {
         data.append(contentsOf: withUnsafeBytes(of: chunkLength.bigEndian) { Array($0) })
         return data
     }
+}
+
+// MARK: - Test Doubles
+
+/// Delegate stub for constructing streaming sessions without a real SDK consumer
+private final class NoopStreamingDelegate: URLSessionDataDelegateProtocol {
+    func urlSession(_ session: URLSessionProtocol, task: URLSessionTaskProtocol, didCompleteWithError error: Error?) {}
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {}
+
+    func urlSession(_ session: URLSessionProtocol, dataTask: URLSessionDataTaskProtocol, didReceive data: Data) {}
+
+    func urlSession(
+        _ session: URLSessionProtocol,
+        dataTask: URLSessionDataTaskProtocol,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
+    ) {}
 }
 
 // MARK: - Extensions


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop buffering the full decrypted response for delegate-driven streaming tasks to reduce peak memory and avoid storing data that’s never read. Added `accumulatesResponse` to `EHBPStreamingDataTask` (disabled for `dataTask(with:)` delegate path, enabled for completion-handler path) and tests to verify both behaviors.

<sup>Written for commit da019785c2f2e4622ffb2706d57edaafcff9c8eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

