### PR TITLE
chore: bump verifier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Tinfoil",
-            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.14.1/Tinfoil.xcframework.zip",
-            checksum: "f0593c66783476a5458af0d75a778363d6995f5a9a324c479ca33b3aef73c1d0"),
+            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.14.2/Tinfoil.xcframework.zip",
+            checksum: "3d12dadcc1fd0a5614af81a6f39c2a92228fcc213bd77750137261322d2e29a7"),
         .target(
             name: "TinfoilAI",
             dependencies: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `Tinfoil` binary target to v0.14.2 to use the latest verifier release. `Package.swift` now points to the new XCFramework URL and checksum.

<sup>Written for commit 1b04e733b373f78c61602ca27a6b9273cc825998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

