### PR TITLE
Chore: bump EHBP package to 0.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.9"),
-        .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.2.0"),
+        .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.3.0"),
     ],
     targets: [
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TinfoilAI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.9"),
+        .package(url: "https://github.com/tinfoilsh/openai-swift-fork.git", exact: "0.0.11"),
         .package(url: "https://github.com/tinfoilsh/encrypted-http-body-protocol.git", from: "0.3.0"),
     ],
     targets: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `encrypted-http-body-protocol` to 0.3.0 and `openai-swift-fork` to 0.0.11 to pick up the latest fixes. Only `Package.swift` changed.

- **Dependencies**
  - Bumped `encrypted-http-body-protocol` from 0.2.0 to 0.3.0.
  - Bumped `openai-swift-fork` from 0.0.9 to 0.0.11.

<sup>Written for commit 098d2158a9546d8148864ef435f91585bfe7c349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

