### PR TITLE
Expose canonical verification documents

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Tinfoil",
-            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.14.2/Tinfoil.xcframework.zip",
-            checksum: "3d12dadcc1fd0a5614af81a6f39c2a92228fcc213bd77750137261322d2e29a7"),
+            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.15.0/Tinfoil.xcframework.zip",
+            checksum: "d81c330f899a42451b8577f9f973d986d64f59996118beff29bf1d26d5de949b"),
         .target(
             name: "TinfoilAI",
             dependencies: [

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ let verificationCallback: VerificationCallback = { verificationDocument in
         print("✅ Attestation verification successful")
         print("Code fingerprint: \(doc.codeFingerprint)")
         print("Enclave fingerprint: \(doc.enclaveFingerprint)")
+        print("Release: \(doc.releaseTag ?? "unavailable")")
+        print("Verifier: \(doc.verifier.name) \(doc.verifier.version)")
+        print("Verified at: \(doc.verifiedAt ?? "unknown")")
         print("Security verified: \(doc.securityVerified)")
         print("All steps succeeded: \(doc.allStepsSucceeded)")
     }

--- a/Sources/TinfoilAI/Constants.swift
+++ b/Sources/TinfoilAI/Constants.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Tinfoil
 
 /// Default configuration constants for Tinfoil
 public enum TinfoilConstants {
@@ -13,6 +14,10 @@ public enum TinfoilConstants {
 
     /// Placeholder for unknown host values
     internal static let unknownHost = "unknown"
+
+    /// Verifier implementation embedded by this SDK release
+    public static let verifierName = "tinfoil-go"
+    public static let verifierVersion = Tinfoil.ClientVersion
 
     /// Error domain for URL parsing errors
     internal static let urlHelpersErrorDomain = "sh.tinfoil.url-helpers"

--- a/Sources/TinfoilAI/Constants.swift
+++ b/Sources/TinfoilAI/Constants.swift
@@ -18,6 +18,8 @@ public enum TinfoilConstants {
     /// Verifier implementation embedded by this SDK release
     public static let verifierName = "tinfoil-go"
     public static let verifierVersion = Tinfoil.ClientVersion
+    internal static let developmentVerifierVersion = "devel"
+    internal static let unknownVerifierValue = "unknown"
 
     /// Error domain for URL parsing errors
     internal static let urlHelpersErrorDomain = "sh.tinfoil.url-helpers"

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -156,7 +156,8 @@ public class SecureClient {
             let decoder = JSONDecoder()
             let decodedGroundTruth = try decoder.decode(GroundTruth.self, from: groundTruthData)
             var document = try decoder.decode(VerificationDocument.self, from: verificationDocumentData)
-            if document.verifier.version == "devel" || document.verifier.version == "unknown" {
+            if document.verifier.version == TinfoilConstants.developmentVerifierVersion ||
+               document.verifier.version == TinfoilConstants.unknownVerifierValue {
                 document = document.replacingVerifier(
                     SoftwareIdentity(
                         name: document.verifier.name,
@@ -180,7 +181,7 @@ public class SecureClient {
                 document.releaseTag == decodedGroundTruth.releaseTag,
                 document.releaseDigest == decodedGroundTruth.digest,
                 document.tlsPublicKey == decodedGroundTruth.tlsPublicKey,
-                document.hpkePublicKey == decodedGroundTruth.hpkePublicKey,
+                document.hpkePublicKey == (decodedGroundTruth.hpkePublicKey ?? ""),
                 document.codeFingerprint == decodedGroundTruth.codeFingerprint,
                 document.enclaveFingerprint == decodedGroundTruth.enclaveFingerprint
             else {

--- a/Sources/TinfoilAI/Verification.swift
+++ b/Sources/TinfoilAI/Verification.swift
@@ -44,7 +44,9 @@ public struct HardwareMeasurementData: Codable {
 
 /// Ground truth structure matching Go's client.GroundTruth
 public struct GroundTruth: Codable {
+    public let configRepo: String?
     public let enclaveHost: String?
+    public let releaseTag: String?
     public let tlsPublicKey: String
     public let hpkePublicKey: String?
     public let digest: String
@@ -53,9 +55,13 @@ public struct GroundTruth: Codable {
     public let hardwareMeasurement: HardwareMeasurementData?
     public let codeFingerprint: String
     public let enclaveFingerprint: String
+    public let verifier: SoftwareIdentity?
+    public let verifiedAt: String?
 
     private enum CodingKeys: String, CodingKey {
+        case configRepo = "config_repo"
         case enclaveHost = "enclave_host"
+        case releaseTag = "release_tag"
         case tlsPublicKey = "tls_public_key"
         case hpkePublicKey = "hpke_public_key"
         case digest
@@ -64,6 +70,8 @@ public struct GroundTruth: Codable {
         case hardwareMeasurement = "hardware_measurement"
         case codeFingerprint = "code_fingerprint"
         case enclaveFingerprint = "enclave_fingerprint"
+        case verifier
+        case verifiedAt = "verified_at"
     }
 }
 
@@ -115,127 +123,116 @@ public class SecureClient {
     /// Verifies the committed code and runtime binaries using remote attestation
     /// - Returns: The ground truth containing all verification results
     public func verify() async throws -> GroundTruth {
-        var steps = VerificationDocument.Steps(
-            fetchDigest: .pending(),
-            verifyCode: .pending(),
-            verifyEnclave: .pending(),
-            compareMeasurements: .pending()
-        )
-
-        let jsonString: String
-
         do {
-            var error: NSError?
-
-            if let attestationBundleURL = attestationBundleURL, !attestationBundleURL.isEmpty {
-                // Verification using custom attestation bundle URL
-                jsonString = Tinfoil.ClientFetchAndVerifyFromURLJSON(attestationBundleURL, githubRepo, nil, &error)
-            } else if let configuredEnclaveURL = configuredEnclaveURL {
-                // Direct enclave verification
-                let urlComponents = try URLHelpers.parseURL(configuredEnclaveURL)
-                jsonString = Tinfoil.ClientVerifyJSON(urlComponents.host, githubRepo, nil, &error)
+            let host: String
+            if let configuredEnclaveURL = configuredEnclaveURL {
+                host = try URLHelpers.parseURL(configuredEnclaveURL).host
             } else {
-                // Default: fetch from Tinfoil's attestation bundle URL
-                jsonString = Tinfoil.ClientFetchAndVerifyJSON(githubRepo, nil, &error)
+                host = ""
             }
 
-            if let error = error {
-                throw error
+            guard let client = ClientNewSecureClient(host, githubRepo) else {
+                throw VerificationError.verificationFailed("Failed to create secure verifier")
+            }
+            if configuredEnclaveURL == nil {
+                client.setAttestationBundleURL(attestationBundleURL ?? TinfoilConstants.attestationBaseURL)
             }
 
-            steps = VerificationDocument.Steps(
-                fetchDigest: .success(),
-                verifyCode: .success(),
-                verifyEnclave: .success(),
-                compareMeasurements: .success()
-            )
-        } catch let error as NSError {
-            let errorMessage = error.localizedDescription
-            steps = Self.stepsFromError(errorMessage)
-            buildFailureDocument(error: error, steps: steps)
-            throw error
-        } catch {
-            buildFailureDocument(error: error, steps: steps)
-            throw error
-        }
+            _ = try client.verify()
 
-        guard let jsonData = jsonString.data(using: String.Encoding.utf8) else {
-            let verificationError = VerificationError.jsonDecodingFailed("Failed to convert JSON string to data")
-            steps = VerificationDocument.Steps(
-                fetchDigest: .success(),
-                verifyCode: .success(),
-                verifyEnclave: .success(),
-                compareMeasurements: .success(),
-                otherError: .failed(verificationError.localizedDescription)
-            )
-            buildFailureDocument(error: verificationError, steps: steps)
-            throw verificationError
-        }
+            var jsonError: NSError?
+            let groundTruthJSON = client.groundTruthJSON(&jsonError)
+            if let jsonError { throw jsonError }
+            let verificationDocumentJSON = client.verificationDocumentJSON(&jsonError)
+            if let jsonError { throw jsonError }
 
-        let decoder = JSONDecoder()
-        do {
-            let groundTruth = try decoder.decode(GroundTruth.self, from: jsonData)
-            self.groundTruth = groundTruth
-
-            // Get enclave host from ground truth (for bundle flow) or configured URL
-            let enclaveHost: String
-            if let host = groundTruth.enclaveHost, !host.isEmpty {
-                enclaveHost = host
-                self.discoveredEnclaveURL = "https://\(host)"
-            } else if let existingURL = configuredEnclaveURL, let urlComponents = try? URLHelpers.parseURL(existingURL) {
-                enclaveHost = urlComponents.host
-            } else {
-                enclaveHost = TinfoilConstants.unknownHost
+            guard
+                let groundTruthData = groundTruthJSON.data(using: String.Encoding.utf8),
+                let verificationDocumentData = verificationDocumentJSON.data(using: String.Encoding.utf8)
+            else {
+                throw VerificationError.jsonDecodingFailed("Failed to convert verification JSON to data")
             }
 
-            let codeMeasurement = AttestationMeasurement(
-                type: groundTruth.codeMeasurement?.type ?? "",
-                registers: groundTruth.codeMeasurement?.registers ?? []
-            )
-
-            let enclaveMeasurement = AttestationResponse(
-                measurement: AttestationMeasurement(
-                    type: groundTruth.enclaveMeasurement?.type ?? "",
-                    registers: groundTruth.enclaveMeasurement?.registers ?? []
-                ),
-                tlsPublicKeyFingerprint: groundTruth.tlsPublicKey.isEmpty ? nil : groundTruth.tlsPublicKey,
-                hpkePublicKey: groundTruth.hpkePublicKey
-            )
-
-            lastVerificationDocument = VerificationDocument(
-                configRepo: githubRepo,
-                enclaveHost: enclaveHost,
-                releaseDigest: groundTruth.digest,
-                codeMeasurement: codeMeasurement,
-                enclaveMeasurement: enclaveMeasurement,
-                tlsPublicKey: groundTruth.tlsPublicKey,
-                hpkePublicKey: groundTruth.hpkePublicKey ?? "",
-                hardwareMeasurement: groundTruth.hardwareMeasurement.map { hw in
-                    HardwareMeasurement(
-                        id: hw.id,
-                        mrtd: hw.mrtd,
-                        rtmr0: hw.rtmr0
+            let decoder = JSONDecoder()
+            let decodedGroundTruth = try decoder.decode(GroundTruth.self, from: groundTruthData)
+            var document = try decoder.decode(VerificationDocument.self, from: verificationDocumentData)
+            if document.verifier.version == "devel" || document.verifier.version == "unknown" {
+                document = document.replacingVerifier(
+                    SoftwareIdentity(
+                        name: document.verifier.name,
+                        version: TinfoilConstants.verifierVersion
                     )
-                },
-                codeFingerprint: groundTruth.codeFingerprint,
-                enclaveFingerprint: groundTruth.enclaveFingerprint,
-                selectedRouterEndpoint: enclaveHost,
-                securityVerified: true,
-                steps: steps
+                )
+            }
+            guard
+                document.schemaVersion == 1,
+                document.securityVerified,
+                document.allStepsSucceeded,
+                !(document.verifiedAt?.isEmpty ?? true),
+                !document.verifier.name.isEmpty,
+                !document.verifier.version.isEmpty
+            else {
+                throw VerificationError.jsonDecodingFailed("Verification document is missing required provenance")
+            }
+            guard
+                document.configRepo == decodedGroundTruth.configRepo,
+                document.enclaveHost == decodedGroundTruth.enclaveHost,
+                document.releaseTag == decodedGroundTruth.releaseTag,
+                document.releaseDigest == decodedGroundTruth.digest,
+                document.tlsPublicKey == decodedGroundTruth.tlsPublicKey,
+                document.hpkePublicKey == decodedGroundTruth.hpkePublicKey,
+                document.codeFingerprint == decodedGroundTruth.codeFingerprint,
+                document.enclaveFingerprint == decodedGroundTruth.enclaveFingerprint
+            else {
+                throw VerificationError.jsonDecodingFailed("Verification document does not match ground truth")
+            }
+
+            let groundTruth = GroundTruth(
+                configRepo: decodedGroundTruth.configRepo,
+                enclaveHost: decodedGroundTruth.enclaveHost,
+                releaseTag: decodedGroundTruth.releaseTag,
+                tlsPublicKey: decodedGroundTruth.tlsPublicKey,
+                hpkePublicKey: decodedGroundTruth.hpkePublicKey,
+                digest: decodedGroundTruth.digest,
+                codeMeasurement: decodedGroundTruth.codeMeasurement,
+                enclaveMeasurement: decodedGroundTruth.enclaveMeasurement,
+                hardwareMeasurement: decodedGroundTruth.hardwareMeasurement,
+                codeFingerprint: decodedGroundTruth.codeFingerprint,
+                enclaveFingerprint: decodedGroundTruth.enclaveFingerprint,
+                verifier: document.verifier,
+                verifiedAt: document.verifiedAt
             )
+
+            self.groundTruth = groundTruth
+            self.lastVerificationDocument = document
+            self.goClient = client
+
+            if let host = groundTruth.enclaveHost, !host.isEmpty {
+                self.discoveredEnclaveURL = "https://\(host)"
+            }
 
             return groundTruth
-        } catch {
+        } catch let error as VerificationError {
+            clearVerifiedState()
+            buildFailureDocument(error: error, steps: .init(otherError: .failed(error.localizedDescription)))
+            throw error
+        } catch let error as DecodingError {
+            clearVerifiedState()
             let decodingError = VerificationError.jsonDecodingFailed(error.localizedDescription)
-            steps = VerificationDocument.Steps(
-                fetchDigest: .success(),
-                verifyCode: .success(),
-                verifyEnclave: .success(),
-                compareMeasurements: .success(),
-                otherError: .failed("Failed to decode verification result: \(error.localizedDescription)")
-            )
-            buildFailureDocument(error: decodingError, steps: steps)
+            buildFailureDocument(error: decodingError, steps: .init(otherError: .failed(decodingError.localizedDescription)))
             throw decodingError
+        } catch let error as NSError {
+            clearVerifiedState()
+            let steps = Self.stepsFromError(
+                error.localizedDescription,
+                usesBundle: configuredEnclaveURL == nil
+            )
+            buildFailureDocument(error: error, steps: steps)
+            throw error
+        } catch {
+            clearVerifiedState()
+            buildFailureDocument(error: error, steps: .init(otherError: .failed(error.localizedDescription)))
+            throw error
         }
     }
 
@@ -306,8 +303,22 @@ public class SecureClient {
     }
 
     /// Maps error message prefixes to verification step states
-    private static func stepsFromError(_ errorMessage: String) -> VerificationDocument.Steps {
-        if errorMessage.starts(with: "fetchDigest:") || errorMessage.starts(with: "failed to fetch bundle:") {
+    internal static func stepsFromError(
+        _ errorMessage: String,
+        usesBundle: Bool = false
+    ) -> VerificationDocument.Steps {
+        let completedFetch: VerificationStepState = usesBundle ? .skipped() : .success()
+        if usesBundle && (errorMessage.starts(with: "fetchBundle:") || errorMessage.starts(with: "failed to fetch bundle:")) {
+            return VerificationDocument.Steps(
+                fetchDigest: .skipped(),
+                verifyCode: .pending(),
+                verifyEnclave: .pending(),
+                compareMeasurements: .pending(),
+                otherError: .failed(errorMessage)
+            )
+        } else if errorMessage.starts(with: "fetchDigest:") ||
+           errorMessage.starts(with: "fetchBundle:") ||
+           errorMessage.starts(with: "failed to fetch bundle:") {
             return VerificationDocument.Steps(
                 fetchDigest: .failed(errorMessage),
                 verifyCode: .pending(),
@@ -316,23 +327,31 @@ public class SecureClient {
             )
         } else if errorMessage.starts(with: "verifyCode:") {
             return VerificationDocument.Steps(
-                fetchDigest: .success(),
+                fetchDigest: completedFetch,
                 verifyCode: .failed(errorMessage),
                 verifyEnclave: .pending(),
                 compareMeasurements: .pending()
             )
         } else if errorMessage.starts(with: "verifyEnclave:") {
             return VerificationDocument.Steps(
-                fetchDigest: .success(),
+                fetchDigest: completedFetch,
                 verifyCode: .success(),
                 verifyEnclave: .failed(errorMessage),
                 compareMeasurements: .pending()
             )
+        } else if errorMessage.starts(with: "validateTLS:") ||
+                  errorMessage.starts(with: "verifyCertificate:") {
+            return VerificationDocument.Steps(
+                fetchDigest: completedFetch,
+                verifyCode: .success(),
+                verifyEnclave: .success(),
+                compareMeasurements: usesBundle ? .success() : .pending(),
+                verifyCertificate: .failed(errorMessage)
+            )
         } else if errorMessage.starts(with: "verifyHardware:") ||
-                  errorMessage.starts(with: "validateTLS:") ||
                   errorMessage.starts(with: "measurements:") {
             return VerificationDocument.Steps(
-                fetchDigest: .success(),
+                fetchDigest: completedFetch,
                 verifyCode: .success(),
                 verifyEnclave: .success(),
                 compareMeasurements: .failed(errorMessage)
@@ -346,6 +365,12 @@ public class SecureClient {
                 otherError: .failed(errorMessage)
             )
         }
+    }
+
+    private func clearVerifiedState() {
+        groundTruth = nil
+        goClient = nil
+        discoveredEnclaveURL = nil
     }
 
     /// Helper method to build a failure verification document

--- a/Sources/TinfoilAI/VerificationDocument.swift
+++ b/Sources/TinfoilAI/VerificationDocument.swift
@@ -274,7 +274,10 @@ public struct VerificationDocument: Codable {
         securityVerified = try container.decode(Bool.self, forKey: .securityVerified)
         if schemaVersion == 0 {
             verifier = try container.decodeIfPresent(SoftwareIdentity.self, forKey: .verifier)
-                ?? SoftwareIdentity(name: "unknown", version: "unknown")
+                ?? SoftwareIdentity(
+                    name: TinfoilConstants.unknownVerifierValue,
+                    version: TinfoilConstants.unknownVerifierValue
+                )
         } else {
             verifier = try container.decode(SoftwareIdentity.self, forKey: .verifier)
         }

--- a/Sources/TinfoilAI/VerificationDocument.swift
+++ b/Sources/TinfoilAI/VerificationDocument.swift
@@ -6,10 +6,11 @@ public typealias VerificationCallback = @Sendable (VerificationDocument?) -> Voi
 
 /// Represents the state of a verification step
 public struct VerificationStepState: Codable {
-    public enum Status: String, Codable {
+    public enum Status: String, Codable, Hashable {
         case pending
         case success
         case failed
+        case skipped
     }
 
     public let status: Status
@@ -26,6 +27,10 @@ public struct VerificationStepState: Codable {
 
     public static func success() -> VerificationStepState {
         return VerificationStepState(status: .success)
+    }
+
+    public static func skipped() -> VerificationStepState {
+        return VerificationStepState(status: .skipped)
     }
 
     public static func failed(_ error: String) -> VerificationStepState {
@@ -72,12 +77,51 @@ public struct HardwareMeasurement: Codable {
         self.mrtd = mrtd
         self.rtmr0 = rtmr0
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "ID"
+        case mrtd = "MRTD"
+        case rtmr0 = "RTMR0"
+    }
+
+    private enum LegacyCodingKeys: String, CodingKey {
+        case id
+        case mrtd
+        case rtmr0
+    }
+
+    public init(from decoder: Decoder) throws {
+        let canonical = try decoder.container(keyedBy: CodingKeys.self)
+        if canonical.contains(.id) {
+            id = try canonical.decode(String.self, forKey: .id)
+            mrtd = try canonical.decode(String.self, forKey: .mrtd)
+            rtmr0 = try canonical.decode(String.self, forKey: .rtmr0)
+        } else {
+            let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            id = try legacy.decode(String.self, forKey: .id)
+            mrtd = try legacy.decode(String.self, forKey: .mrtd)
+            rtmr0 = try legacy.decode(String.self, forKey: .rtmr0)
+        }
+    }
+}
+
+/// Identifies the software that performed verification
+public struct SoftwareIdentity: Codable {
+    public let name: String
+    public let version: String
+
+    public init(name: String, version: String) {
+        self.name = name
+        self.version = version
+    }
 }
 
 /// Complete verification document containing all verification details
 public struct VerificationDocument: Codable {
+    public let schemaVersion: Int
     public let configRepo: String
     public let enclaveHost: String
+    public let releaseTag: String?
     public let releaseDigest: String
     public let codeMeasurement: AttestationMeasurement
     public let enclaveMeasurement: AttestationResponse
@@ -88,6 +132,8 @@ public struct VerificationDocument: Codable {
     public let enclaveFingerprint: String
     public let selectedRouterEndpoint: String
     public let securityVerified: Bool
+    public let verifier: SoftwareIdentity
+    public let verifiedAt: String?
 
     /// Detailed step-by-step verification status
     public struct Steps: Codable {
@@ -95,6 +141,8 @@ public struct VerificationDocument: Codable {
         public let verifyCode: VerificationStepState
         public let verifyEnclave: VerificationStepState
         public let compareMeasurements: VerificationStepState
+        public let verifyCertificate: VerificationStepState
+        internal let includesVerifyCertificate: Bool
         public let createTransport: VerificationStepState?
         public let verifyHPKEKey: VerificationStepState?
         public let otherError: VerificationStepState?
@@ -104,6 +152,7 @@ public struct VerificationDocument: Codable {
             verifyCode: VerificationStepState = .pending(),
             verifyEnclave: VerificationStepState = .pending(),
             compareMeasurements: VerificationStepState = .pending(),
+            verifyCertificate: VerificationStepState = .pending(),
             createTransport: VerificationStepState? = nil,
             verifyHPKEKey: VerificationStepState? = nil,
             otherError: VerificationStepState? = nil
@@ -112,9 +161,35 @@ public struct VerificationDocument: Codable {
             self.verifyCode = verifyCode
             self.verifyEnclave = verifyEnclave
             self.compareMeasurements = compareMeasurements
+            self.verifyCertificate = verifyCertificate
+            self.includesVerifyCertificate = true
             self.createTransport = createTransport
             self.verifyHPKEKey = verifyHPKEKey
             self.otherError = otherError
+        }
+
+        fileprivate enum CodingKeys: String, CodingKey {
+            case fetchDigest
+            case verifyCode
+            case verifyEnclave
+            case compareMeasurements
+            case verifyCertificate
+            case createTransport
+            case verifyHPKEKey
+            case otherError
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            fetchDigest = try container.decode(VerificationStepState.self, forKey: .fetchDigest)
+            verifyCode = try container.decode(VerificationStepState.self, forKey: .verifyCode)
+            verifyEnclave = try container.decode(VerificationStepState.self, forKey: .verifyEnclave)
+            compareMeasurements = try container.decode(VerificationStepState.self, forKey: .compareMeasurements)
+            verifyCertificate = try container.decodeIfPresent(VerificationStepState.self, forKey: .verifyCertificate) ?? .pending()
+            includesVerifyCertificate = container.contains(.verifyCertificate)
+            createTransport = try container.decodeIfPresent(VerificationStepState.self, forKey: .createTransport)
+            verifyHPKEKey = try container.decodeIfPresent(VerificationStepState.self, forKey: .verifyHPKEKey)
+            otherError = try container.decodeIfPresent(VerificationStepState.self, forKey: .otherError)
         }
     }
 
@@ -133,10 +208,19 @@ public struct VerificationDocument: Codable {
         enclaveFingerprint: String,
         selectedRouterEndpoint: String,
         securityVerified: Bool,
-        steps: Steps
+        steps: Steps,
+        schemaVersion: Int = 1,
+        releaseTag: String? = nil,
+        verifier: SoftwareIdentity = SoftwareIdentity(
+            name: TinfoilConstants.verifierName,
+            version: TinfoilConstants.verifierVersion
+        ),
+        verifiedAt: String? = nil
     ) {
+        self.schemaVersion = schemaVersion
         self.configRepo = configRepo
         self.enclaveHost = enclaveHost
+        self.releaseTag = releaseTag
         self.releaseDigest = releaseDigest
         self.codeMeasurement = codeMeasurement
         self.enclaveMeasurement = enclaveMeasurement
@@ -147,7 +231,64 @@ public struct VerificationDocument: Codable {
         self.enclaveFingerprint = enclaveFingerprint
         self.selectedRouterEndpoint = selectedRouterEndpoint
         self.securityVerified = securityVerified
+        self.verifier = verifier
+        self.verifiedAt = verifiedAt
         self.steps = steps
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case configRepo
+        case enclaveHost
+        case releaseTag
+        case releaseDigest
+        case codeMeasurement
+        case enclaveMeasurement
+        case tlsPublicKey
+        case hpkePublicKey
+        case hardwareMeasurement
+        case codeFingerprint
+        case enclaveFingerprint
+        case selectedRouterEndpoint
+        case securityVerified
+        case verifier
+        case verifiedAt
+        case steps
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 0
+        configRepo = try container.decode(String.self, forKey: .configRepo)
+        enclaveHost = try container.decode(String.self, forKey: .enclaveHost)
+        releaseTag = try container.decodeIfPresent(String.self, forKey: .releaseTag)
+        releaseDigest = try container.decode(String.self, forKey: .releaseDigest)
+        codeMeasurement = try container.decode(AttestationMeasurement.self, forKey: .codeMeasurement)
+        enclaveMeasurement = try container.decode(AttestationResponse.self, forKey: .enclaveMeasurement)
+        tlsPublicKey = try container.decode(String.self, forKey: .tlsPublicKey)
+        hpkePublicKey = try container.decode(String.self, forKey: .hpkePublicKey)
+        hardwareMeasurement = try container.decodeIfPresent(HardwareMeasurement.self, forKey: .hardwareMeasurement)
+        codeFingerprint = try container.decode(String.self, forKey: .codeFingerprint)
+        enclaveFingerprint = try container.decode(String.self, forKey: .enclaveFingerprint)
+        selectedRouterEndpoint = try container.decode(String.self, forKey: .selectedRouterEndpoint)
+        securityVerified = try container.decode(Bool.self, forKey: .securityVerified)
+        if schemaVersion == 0 {
+            verifier = try container.decodeIfPresent(SoftwareIdentity.self, forKey: .verifier)
+                ?? SoftwareIdentity(name: "unknown", version: "unknown")
+        } else {
+            verifier = try container.decode(SoftwareIdentity.self, forKey: .verifier)
+        }
+        verifiedAt = try container.decodeIfPresent(String.self, forKey: .verifiedAt)
+        steps = try container.decode(Steps.self, forKey: .steps)
+        if schemaVersion == 1 && !steps.includesVerifyCertificate {
+            throw DecodingError.keyNotFound(
+                Steps.CodingKeys.verifyCertificate,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "schemaVersion 1 requires verifyCertificate"
+                )
+            )
+        }
     }
 }
 
@@ -155,10 +296,12 @@ public struct VerificationDocument: Codable {
 public extension VerificationDocument {
     /// Check if all verification steps succeeded
     var allStepsSucceeded: Bool {
-        return steps.fetchDigest.status == .success &&
-               steps.verifyCode.status == .success &&
-               steps.verifyEnclave.status == .success &&
-               steps.compareMeasurements.status == .success
+        let completed: Set<VerificationStepState.Status> = [.success, .skipped]
+        return completed.contains(steps.fetchDigest.status) &&
+               completed.contains(steps.verifyCode.status) &&
+               completed.contains(steps.verifyEnclave.status) &&
+               completed.contains(steps.compareMeasurements.status) &&
+               completed.contains(steps.verifyCertificate.status)
     }
 
     /// Get a human-readable summary of the verification
@@ -178,9 +321,34 @@ public extension VerificationDocument {
         if let error = steps.verifyCode.error { return error }
         if let error = steps.verifyEnclave.error { return error }
         if let error = steps.compareMeasurements.error { return error }
+        if let error = steps.verifyCertificate.error { return error }
         if let error = steps.createTransport?.error { return error }
         if let error = steps.verifyHPKEKey?.error { return error }
         if let error = steps.otherError?.error { return error }
         return nil
+    }
+}
+
+internal extension VerificationDocument {
+    func replacingVerifier(_ verifier: SoftwareIdentity) -> VerificationDocument {
+        VerificationDocument(
+            configRepo: configRepo,
+            enclaveHost: enclaveHost,
+            releaseDigest: releaseDigest,
+            codeMeasurement: codeMeasurement,
+            enclaveMeasurement: enclaveMeasurement,
+            tlsPublicKey: tlsPublicKey,
+            hpkePublicKey: hpkePublicKey,
+            hardwareMeasurement: hardwareMeasurement,
+            codeFingerprint: codeFingerprint,
+            enclaveFingerprint: enclaveFingerprint,
+            selectedRouterEndpoint: selectedRouterEndpoint,
+            securityVerified: securityVerified,
+            steps: steps,
+            schemaVersion: schemaVersion,
+            releaseTag: releaseTag,
+            verifier: verifier,
+            verifiedAt: verifiedAt
+        )
     }
 }

--- a/Tests/TinfoilAITests.swift
+++ b/Tests/TinfoilAITests.swift
@@ -223,15 +223,7 @@ final class TinfoilAITests: XCTestCase {
             XCTAssertFalse(doc.selectedRouterEndpoint.isEmpty, "Selected router endpoint should be present")
             XCTAssertTrue(doc.securityVerified, "Security should be verified for successful flow")
 
-            // Verify all steps are successful
-            if doc.steps.fetchDigest.status == .success,
-               doc.steps.verifyCode.status == .success,
-               doc.steps.verifyEnclave.status == .success,
-               doc.steps.compareMeasurements.status == .success {
-                XCTAssertTrue(true, "All verification steps should be successful")
-            } else {
-                XCTFail("Not all verification steps were successful")
-            }
+            XCTAssertTrue(doc.allStepsSucceeded, "All verification steps should be complete")
         }
 
         let chatQuery = ChatQuery(

--- a/Tests/VerificationTests.swift
+++ b/Tests/VerificationTests.swift
@@ -42,13 +42,20 @@ final class VerificationTests: XCTestCase {
             XCTAssertEqual(verificationDoc?.codeFingerprint, groundTruth.codeFingerprint, "Code fingerprint should match")
             XCTAssertEqual(verificationDoc?.enclaveFingerprint, groundTruth.enclaveFingerprint, "Enclave fingerprint should match")
             XCTAssertFalse(verificationDoc?.selectedRouterEndpoint.isEmpty ?? true, "Router endpoint should be populated")
+            XCTAssertEqual(verificationDoc?.schemaVersion, 1)
+            XCTAssertEqual(verificationDoc?.verifier.name, TinfoilConstants.verifierName)
+            XCTAssertEqual(verificationDoc?.verifier.version, TinfoilConstants.verifierVersion)
+            XCTAssertNotNil(verificationDoc?.verifiedAt)
+            XCTAssertEqual(verificationDoc?.steps.fetchDigest.status, .skipped)
+            XCTAssertEqual(verificationDoc?.steps.verifyCertificate.status, .success)
+            XCTAssertTrue(verificationDoc?.allStepsSucceeded ?? false)
 
             // Verify verifiedEnclaveURL returns the discovered enclave
             let enclaveURL = secureClient.verifiedEnclaveURL
             XCTAssertNotNil(enclaveURL, "Enclave URL should be available after verification")
             XCTAssertTrue(enclaveURL?.starts(with: "https://") ?? false, "Enclave URL should be HTTPS")
         } catch {
-            // If this fails in CI, it might be due to network issues
+            throw XCTSkip("Network verification unavailable: \(error)")
         }
     }
 
@@ -154,34 +161,43 @@ final class VerificationTests: XCTestCase {
         // Test error prefix detection logic
         let testCases: [(error: String, expectedStep: String)] = [
             ("fetchDigest: failed to connect", "fetchDigest"),
+            ("fetchBundle: connection refused", "fetchDigest"),
             ("failed to fetch bundle: connection refused", "fetchDigest"),
             ("verifyCode: invalid repository", "verifyCode"),
             ("verifyEnclave: measurement mismatch", "verifyEnclave"),
-            ("verifyHardware: TDX attestation failed", "verifyHardware"),
-            ("validateTLS: certificate invalid", "validateTLS"),
-            ("measurements: comparison failed", "validateTLS"),
+            ("verifyHardware: TDX attestation failed", "compareMeasurements"),
+            ("validateTLS: certificate invalid", "verifyCertificate"),
+            ("verifyCertificate: binding failed", "verifyCertificate"),
+            ("measurements: comparison failed", "compareMeasurements"),
             ("unknown error without prefix", "other")
         ]
 
         for testCase in testCases {
-            let errorMessage = testCase.error
-            var detectedStep = "other"
+            let steps = SecureClient.stepsFromError(testCase.error)
+            let failedStep: String
+            if steps.fetchDigest.status == .failed { failedStep = "fetchDigest" }
+            else if steps.verifyCode.status == .failed { failedStep = "verifyCode" }
+            else if steps.verifyEnclave.status == .failed { failedStep = "verifyEnclave" }
+            else if steps.compareMeasurements.status == .failed { failedStep = "compareMeasurements" }
+            else if steps.verifyCertificate.status == .failed { failedStep = "verifyCertificate" }
+            else { failedStep = "other" }
 
-            if errorMessage.starts(with: "fetchDigest:") || errorMessage.starts(with: "failed to fetch bundle:") {
-                detectedStep = "fetchDigest"
-            } else if errorMessage.starts(with: "verifyCode:") {
-                detectedStep = "verifyCode"
-            } else if errorMessage.starts(with: "verifyEnclave:") {
-                detectedStep = "verifyEnclave"
-            } else if errorMessage.starts(with: "verifyHardware:") {
-                detectedStep = "verifyHardware"
-            } else if errorMessage.starts(with: "validateTLS:") || errorMessage.starts(with: "measurements:") {
-                detectedStep = "validateTLS"
-            }
-
-            XCTAssertEqual(detectedStep, testCase.expectedStep,
-                          "Error '\(errorMessage)' should be detected as '\(testCase.expectedStep)' step")
+            XCTAssertEqual(failedStep, testCase.expectedStep)
         }
+
+        let bundleCodeFailure = SecureClient.stepsFromError(
+            "verifyCode: invalid signature",
+            usesBundle: true
+        )
+        XCTAssertEqual(bundleCodeFailure.fetchDigest.status, .skipped)
+        XCTAssertEqual(bundleCodeFailure.verifyCode.status, .failed)
+
+        let bundleFetchFailure = SecureClient.stepsFromError(
+            "fetchBundle: connection refused",
+            usesBundle: true
+        )
+        XCTAssertEqual(bundleFetchFailure.fetchDigest.status, .skipped)
+        XCTAssertEqual(bundleFetchFailure.otherError?.status, .failed)
     }
 
     // MARK: - Verification Document Tests
@@ -211,14 +227,23 @@ final class VerificationTests: XCTestCase {
                 fetchDigest: .success(),
                 verifyCode: .success(),
                 verifyEnclave: .success(),
-                compareMeasurements: .success()
-            )
+                compareMeasurements: .success(),
+                verifyCertificate: .success()
+            ),
+            releaseTag: "v1.2.3",
+            verifier: SoftwareIdentity(name: "tinfoil-go", version: "0.15.0"),
+            verifiedAt: "2026-08-04T12:30:00Z"
         )
 
         // Verify all fields are accessible
         XCTAssertEqual(testDoc.configRepo, "test-repo")
         XCTAssertEqual(testDoc.enclaveHost, "test-url")
         XCTAssertEqual(testDoc.releaseDigest, "test-digest")
+        XCTAssertEqual(testDoc.schemaVersion, 1)
+        XCTAssertEqual(testDoc.releaseTag, "v1.2.3")
+        XCTAssertEqual(testDoc.verifier.name, "tinfoil-go")
+        XCTAssertEqual(testDoc.verifier.version, "0.15.0")
+        XCTAssertEqual(testDoc.verifiedAt, "2026-08-04T12:30:00Z")
         XCTAssertEqual(testDoc.tlsPublicKey, "test-tls")
         XCTAssertEqual(testDoc.hpkePublicKey, "test-hpke")
         XCTAssertEqual(testDoc.codeFingerprint, "code-fp")
@@ -227,6 +252,122 @@ final class VerificationTests: XCTestCase {
         XCTAssertTrue(testDoc.securityVerified)
         XCTAssertNotNil(testDoc.hardwareMeasurement)
         XCTAssertEqual(testDoc.hardwareMeasurement?.id, "TDX-1")
+    }
+
+    func testLegacyVerificationDocumentDecoding() throws {
+        let json = """
+        {
+          "configRepo":"owner/repo",
+          "enclaveHost":"router.example",
+          "releaseDigest":"digest",
+          "codeMeasurement":{"type":"type","registers":["code"]},
+          "enclaveMeasurement":{"measurement":{"type":"type","registers":["enclave"]}},
+          "tlsPublicKey":"tls",
+          "hpkePublicKey":"hpke",
+          "hardwareMeasurement":{"id":"id","mrtd":"mrtd","rtmr0":"rtmr0"},
+          "codeFingerprint":"code-fingerprint",
+          "enclaveFingerprint":"enclave-fingerprint",
+          "selectedRouterEndpoint":"router.example",
+          "securityVerified":true,
+          "steps":{
+            "fetchDigest":{"status":"success"},
+            "verifyCode":{"status":"success"},
+            "verifyEnclave":{"status":"success"},
+            "compareMeasurements":{"status":"success"}
+          }
+        }
+        """
+
+        let document = try JSONDecoder().decode(
+            VerificationDocument.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(document.schemaVersion, 0)
+        XCTAssertEqual(document.verifier.name, "unknown")
+        XCTAssertEqual(document.steps.verifyCertificate.status, .pending)
+        XCTAssertEqual(document.hardwareMeasurement?.id, "id")
+    }
+
+    func testCanonicalVerificationDocumentDecoding() throws {
+        let json = """
+        {
+          "schemaVersion":1,
+          "configRepo":"owner/repo",
+          "enclaveHost":"router.example",
+          "releaseTag":"v1.2.3",
+          "releaseDigest":"digest",
+          "codeMeasurement":{"type":"type","registers":["code"]},
+          "enclaveMeasurement":{"measurement":{"type":"type","registers":["enclave"]}},
+          "tlsPublicKey":"tls",
+          "hpkePublicKey":"hpke",
+          "hardwareMeasurement":{"ID":"id","MRTD":"mrtd","RTMR0":"rtmr0"},
+          "codeFingerprint":"code-fingerprint",
+          "enclaveFingerprint":"enclave-fingerprint",
+          "selectedRouterEndpoint":"router.example",
+          "securityVerified":true,
+          "verifier":{"name":"tinfoil-go","version":"0.15.0"},
+          "verifiedAt":"2026-08-04T12:30:00Z",
+          "steps":{
+            "fetchDigest":{"status":"success"},
+            "verifyCode":{"status":"success"},
+            "verifyEnclave":{"status":"success"},
+            "compareMeasurements":{"status":"success"},
+            "verifyCertificate":{"status":"success"}
+          }
+        }
+        """
+
+        let document = try JSONDecoder().decode(
+            VerificationDocument.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertTrue(document.allStepsSucceeded)
+        XCTAssertEqual(document.verifier.version, "0.15.0")
+        XCTAssertEqual(document.hardwareMeasurement?.id, "id")
+
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        var steps = try XCTUnwrap(object["steps"] as? [String: Any])
+        steps.removeValue(forKey: "verifyCertificate")
+        object["steps"] = steps
+        let missingCertificateStep = try JSONSerialization.data(withJSONObject: object)
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(VerificationDocument.self, from: missingCertificateStep)
+        )
+    }
+
+    func testCanonicalDocumentRequiresVerifierIdentity() {
+        let json = """
+        {
+          "schemaVersion":1,
+          "configRepo":"owner/repo",
+          "enclaveHost":"router.example",
+          "releaseDigest":"digest",
+          "codeMeasurement":{"type":"type","registers":["code"]},
+          "enclaveMeasurement":{"measurement":{"type":"type","registers":["enclave"]}},
+          "tlsPublicKey":"tls",
+          "hpkePublicKey":"hpke",
+          "codeFingerprint":"code-fingerprint",
+          "enclaveFingerprint":"enclave-fingerprint",
+          "selectedRouterEndpoint":"router.example",
+          "securityVerified":true,
+          "verifiedAt":"2026-08-04T12:30:00Z",
+          "steps":{
+            "fetchDigest":{"status":"success"},
+            "verifyCode":{"status":"success"},
+            "verifyEnclave":{"status":"success"},
+            "compareMeasurements":{"status":"success"},
+            "verifyCertificate":{"status":"success"}
+          }
+        }
+        """
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(VerificationDocument.self, from: Data(json.utf8))
+        )
     }
 
     // MARK: - SecureClient HTTP Methods


### PR DESCRIPTION
## Summary
- consume canonical Verification Document v1 JSON from the retained Go secure client
- keep verification metadata and the active request transport bound to the same verified state
- add release, verifier, timestamp, certificate-step, and skipped-step support with legacy decoding
- update the embedded Go verifier framework to v0.15.0; release this Swift SDK as v0.7.0 after merge

## Testing
- `swift test` (102 tests, 6 API-key-dependent tests skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose canonical Verification Document v1 from the embedded Go secure client and validate provenance (release, verifier, timestamp) end-to-end. Normalizes verifier identity/version from the embedded client and updates to `tinfoil-go` v0.15.0.

- **New Features**
  - Return and persist canonical Verification Document v1; validate schema, `verifiedAt`, and verifier identity (normalize "devel"/unknown to embedded version).
  - Enforce strict match between verification document and ground truth (repo, host, `releaseTag`, digest, TLS/HPKE keys, fingerprints).
  - Add `verifyCertificate` step and `skipped` status; `allStepsSucceeded` treats skipped as complete (bundle and direct flows).
  - Back-compat decoding for legacy documents (legacy hardware key casing and no certificate step).
  - Improved error mapping for bundle vs direct flows; build failure documents, clear verified state on errors.
  - Bind HTTP transport to the current verified state; expose discovered enclave URL.
  - README prints release tag, verifier, and verification time.
  - Bump embedded verifier to `tinfoil-go` v0.15.0.

- **Migration**
  - For schema v1 documents, include the `verifyCertificate` step; decoding fails if it’s missing.
  - Handle the new `skipped` status and `verifyCertificate` step in any UI or logic using step states.
  - Read verifier identity via `doc.verifier` and timestamp via `doc.verifiedAt`.

<sup>Written for commit 93ba1a3398533ec08c2a944c399330a60b2e9eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

