### PR TITLE
Make streaming cancellation race-safe

### DIFF
--- a/Sources/TinfoilAI/EHBPURLSession.swift
+++ b/Sources/TinfoilAI/EHBPURLSession.swift
@@ -182,6 +182,8 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
 
     private var underlyingTask: Task<Void, Never>?
     private var hasStarted = false
+    private var isCancellationRequested = false
+    private var hasCompleted = false
     private let lock = NSLock()
     private var _originalRequest: URLRequest?
 
@@ -216,34 +218,47 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
 
     func resume() {
         lock.lock()
-        guard !hasStarted else {
+        guard !hasStarted, !isCancellationRequested, !hasCompleted else {
             lock.unlock()
             return
         }
         hasStarted = true
-        lock.unlock()
-
-        underlyingTask = Task { [weak self] in
+        let task = Task { [weak self] in
             guard let self = self else { return }
             await self.performStreamingRequest()
         }
+        underlyingTask = task
+        lock.unlock()
     }
 
     func cancel() {
         lock.lock()
+        guard !isCancellationRequested, !hasCompleted else {
+            lock.unlock()
+            return
+        }
+        isCancellationRequested = true
         let task = underlyingTask
+        let shouldCompleteImmediately = !hasStarted
         lock.unlock()
         task?.cancel()
-        session?.removeTask(self)
+        if shouldCompleteImmediately {
+            finish(data: nil, response: nil, error: CancellationError())
+        }
     }
 
     private func performStreamingRequest() async {
         guard let session = session else {
-            completionHandler(nil, nil, EHBPError.invalidInput("session was deallocated"))
+            finish(
+                data: nil,
+                response: nil,
+                error: EHBPError.invalidInput("session was deallocated")
+            )
             return
         }
 
         do {
+            try Task.checkCancellation()
             let ehbpClient = try EHBPClient(baseURL: baseURL, publicKey: publicKey)
 
             guard let url = request.url else {
@@ -294,14 +309,31 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
             }
             try Task.checkCancellation()
 
-            completionHandler(accumulatedData, response, nil)
-            delegate?.urlSession(session, task: self, didCompleteWithError: nil)
+            finish(data: accumulatedData, response: response, error: nil)
         } catch {
-            completionHandler(nil, nil, error)
-            delegate?.urlSession(session, task: self, didCompleteWithError: error)
+            finish(data: nil, response: nil, error: error)
         }
+    }
 
-        session.removeTask(self)
+    private func finish(data: Data?, response: URLResponse?, error: Error?) {
+        lock.lock()
+        guard !hasCompleted else {
+            lock.unlock()
+            return
+        }
+        hasCompleted = true
+        underlyingTask = nil
+        let wasCancelled = isCancellationRequested
+        let finalData = wasCancelled ? nil : data
+        let finalResponse = wasCancelled ? nil : response
+        let finalError: Error? = wasCancelled ? CancellationError() : error
+        lock.unlock()
+
+        completionHandler(finalData, finalResponse, finalError)
+        if let session {
+            delegate?.urlSession(session, task: self, didCompleteWithError: finalError)
+            session.removeTask(self)
+        }
     }
 }
 

--- a/Sources/TinfoilAI/EHBPURLSession.swift
+++ b/Sources/TinfoilAI/EHBPURLSession.swift
@@ -218,7 +218,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
 
     func resume() {
         lock.lock()
-        guard !hasStarted, !isCancellationRequested, !hasCompleted else {
+        guard !hasStarted, !isCancellationRequested else {
             lock.unlock()
             return
         }
@@ -243,7 +243,9 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
         lock.unlock()
         task?.cancel()
         if shouldCompleteImmediately {
-            finish(data: nil, response: nil, error: URLError(.cancelled))
+            Task { [self] in
+                finish(data: nil, response: nil, error: nil)
+            }
         }
     }
 

--- a/Sources/TinfoilAI/EHBPURLSession.swift
+++ b/Sources/TinfoilAI/EHBPURLSession.swift
@@ -223,9 +223,8 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
             return
         }
         hasStarted = true
-        let task = Task { [weak self] in
-            guard let self = self else { return }
-            await self.performStreamingRequest()
+        let task = Task { [self] in
+            await performStreamingRequest()
         }
         underlyingTask = task
         lock.unlock()

--- a/Sources/TinfoilAI/EHBPURLSession.swift
+++ b/Sources/TinfoilAI/EHBPURLSession.swift
@@ -243,7 +243,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
         lock.unlock()
         task?.cancel()
         if shouldCompleteImmediately {
-            finish(data: nil, response: nil, error: CancellationError())
+            finish(data: nil, response: nil, error: URLError(.cancelled))
         }
     }
 
@@ -326,7 +326,7 @@ internal final class EHBPStreamingDataTask: URLSessionDataTaskProtocol, @uncheck
         let wasCancelled = isCancellationRequested
         let finalData = wasCancelled ? nil : data
         let finalResponse = wasCancelled ? nil : response
-        let finalError: Error? = wasCancelled ? CancellationError() : error
+        let finalError: Error? = wasCancelled ? URLError(.cancelled) : error
         lock.unlock()
 
         completionHandler(finalData, finalResponse, finalError)

--- a/Tests/EHBPTests.swift
+++ b/Tests/EHBPTests.swift
@@ -648,6 +648,32 @@ final class EHBPTests: XCTestCase {
         XCTAssertEqual(recorder.completionCount, 1)
     }
 
+    func testStreamingTaskCancelledBeforeResumeNeverStartsRequest() async throws {
+        let completionCalled = expectation(description: "completion handler")
+        let recorder = CancellationRecorder(completionCalled: completionCalled)
+        let session = EHBPStreamingSession(
+            baseURL: server.baseURL,
+            publicKey: testPublicKey,
+            delegate: recorder
+        )
+        let request = URLRequest(url: URL(string: "\(server.baseURL)/v1/models")!)
+        let task = session.dataTask(with: request) { data, response, error in
+            recorder.recordCompletion(data: data, response: response, error: error)
+        }
+
+        task.cancel()
+        task.resume()
+
+        await fulfillment(of: [completionCalled], timeout: 2)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(server.requestStore.requests.isEmpty)
+        XCTAssertNil(recorder.completionData)
+        XCTAssertNil(recorder.completionResponse)
+        XCTAssertTrue(recorder.completionError is CancellationError)
+        XCTAssertEqual(recorder.completionCount, 1)
+    }
+
     // MARK: - Protocol Constants Tests
 
     func testEHBPProtocolConstants() {

--- a/Tests/EHBPTests.swift
+++ b/Tests/EHBPTests.swift
@@ -249,7 +249,6 @@ final class EHBPTests: XCTestCase {
 
     /// A valid 32-byte X25519 public key for testing
     private let testPublicKey = Data(repeating: 0x42, count: 32)
-    private let cancellationObservationDelayNanoseconds: UInt64 = 100_000_000
 
     private var server: LocalTestServer!
 
@@ -628,7 +627,11 @@ final class EHBPTests: XCTestCase {
     func testStreamingCancellationDoesNotReturnPartialData() async throws {
         server.responseBody = Data("partial".utf8)
         let completionCalled = expectation(description: "completion handler")
-        let recorder = CancellationRecorder(completionCalled: completionCalled)
+        let delegateCompleted = expectation(description: "delegate completion")
+        let recorder = CancellationRecorder(
+            completionCalled: completionCalled,
+            delegateCompleted: delegateCompleted
+        )
         let session = EHBPStreamingSession(
             baseURL: server.baseURL,
             publicKey: testPublicKey,
@@ -640,7 +643,7 @@ final class EHBPTests: XCTestCase {
             recorder.recordCompletion(data: data, response: response, error: error)
         }.resume()
 
-        await fulfillment(of: [completionCalled], timeout: 2)
+        await fulfillment(of: [completionCalled, delegateCompleted], timeout: 2)
 
         XCTAssertEqual(recorder.receivedData, Data("partial".utf8))
         XCTAssertNil(recorder.completionData)
@@ -652,7 +655,11 @@ final class EHBPTests: XCTestCase {
 
     func testStreamingTaskCancelledBeforeResumeNeverStartsRequest() async throws {
         let completionCalled = expectation(description: "completion handler")
-        let recorder = CancellationRecorder(completionCalled: completionCalled)
+        let delegateCompleted = expectation(description: "delegate completion")
+        let recorder = CancellationRecorder(
+            completionCalled: completionCalled,
+            delegateCompleted: delegateCompleted
+        )
         let session = EHBPStreamingSession(
             baseURL: server.baseURL,
             publicKey: testPublicKey,
@@ -666,8 +673,7 @@ final class EHBPTests: XCTestCase {
         task.cancel()
         task.resume()
 
-        await fulfillment(of: [completionCalled], timeout: 2)
-        try await Task.sleep(nanoseconds: cancellationObservationDelayNanoseconds)
+        await fulfillment(of: [completionCalled, delegateCompleted], timeout: 2)
 
         XCTAssertTrue(server.requestStore.requests.isEmpty)
         XCTAssertNil(recorder.completionData)
@@ -679,7 +685,11 @@ final class EHBPTests: XCTestCase {
 
     func testConcurrentStreamingResumeAndCancelCompletesOnce() async throws {
         let completionCalled = expectation(description: "completion handler")
-        let recorder = CancellationRecorder(completionCalled: completionCalled)
+        let delegateCompleted = expectation(description: "delegate completion")
+        let recorder = CancellationRecorder(
+            completionCalled: completionCalled,
+            delegateCompleted: delegateCompleted
+        )
         let session = EHBPStreamingSession(
             baseURL: server.baseURL,
             publicKey: testPublicKey,
@@ -695,8 +705,7 @@ final class EHBPTests: XCTestCase {
             group.addTask { task.cancel() }
         }
 
-        await fulfillment(of: [completionCalled], timeout: 2)
-        try await Task.sleep(nanoseconds: cancellationObservationDelayNanoseconds)
+        await fulfillment(of: [completionCalled, delegateCompleted], timeout: 2)
 
         XCTAssertNil(recorder.completionData)
         XCTAssertNil(recorder.completionResponse)
@@ -1899,6 +1908,7 @@ final class EHBPTests: XCTestCase {
 private final class CancellationRecorder: URLSessionDataDelegateProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private let completionCalled: XCTestExpectation
+    private let delegateCompleted: XCTestExpectation
     private var cancelled = false
     private var _receivedData = Data()
     private var _completionData: Data?
@@ -1943,8 +1953,12 @@ private final class CancellationRecorder: URLSessionDataDelegateProtocol, @unche
         return _delegateCompletionCount
     }
 
-    init(completionCalled: XCTestExpectation) {
+    init(
+        completionCalled: XCTestExpectation,
+        delegateCompleted: XCTestExpectation
+    ) {
         self.completionCalled = completionCalled
+        self.delegateCompleted = delegateCompleted
     }
 
     func recordCompletion(data: Data?, response: URLResponse?, error: Error?) {
@@ -1963,7 +1977,11 @@ private final class CancellationRecorder: URLSessionDataDelegateProtocol, @unche
     func urlSession(_ session: URLSessionProtocol, task: URLSessionTaskProtocol, didCompleteWithError error: Error?) {
         lock.lock()
         _delegateCompletionCount += 1
+        let shouldFulfill = _delegateCompletionCount == 1
         lock.unlock()
+        if shouldFulfill {
+            delegateCompleted.fulfill()
+        }
     }
 
     func urlSession(

--- a/Tests/EHBPTests.swift
+++ b/Tests/EHBPTests.swift
@@ -249,6 +249,7 @@ final class EHBPTests: XCTestCase {
 
     /// A valid 32-byte X25519 public key for testing
     private let testPublicKey = Data(repeating: 0x42, count: 32)
+    private let cancellationObservationDelayNanoseconds: UInt64 = 100_000_000
 
     private var server: LocalTestServer!
 
@@ -644,8 +645,9 @@ final class EHBPTests: XCTestCase {
         XCTAssertEqual(recorder.receivedData, Data("partial".utf8))
         XCTAssertNil(recorder.completionData)
         XCTAssertNil(recorder.completionResponse)
-        XCTAssertTrue(recorder.completionError is CancellationError)
+        XCTAssertEqual((recorder.completionError as? URLError)?.code, .cancelled)
         XCTAssertEqual(recorder.completionCount, 1)
+        XCTAssertEqual(recorder.delegateCompletionCount, 1)
     }
 
     func testStreamingTaskCancelledBeforeResumeNeverStartsRequest() async throws {
@@ -665,13 +667,42 @@ final class EHBPTests: XCTestCase {
         task.resume()
 
         await fulfillment(of: [completionCalled], timeout: 2)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(nanoseconds: cancellationObservationDelayNanoseconds)
 
         XCTAssertTrue(server.requestStore.requests.isEmpty)
         XCTAssertNil(recorder.completionData)
         XCTAssertNil(recorder.completionResponse)
-        XCTAssertTrue(recorder.completionError is CancellationError)
+        XCTAssertEqual((recorder.completionError as? URLError)?.code, .cancelled)
         XCTAssertEqual(recorder.completionCount, 1)
+        XCTAssertEqual(recorder.delegateCompletionCount, 1)
+    }
+
+    func testConcurrentStreamingResumeAndCancelCompletesOnce() async throws {
+        let completionCalled = expectation(description: "completion handler")
+        let recorder = CancellationRecorder(completionCalled: completionCalled)
+        let session = EHBPStreamingSession(
+            baseURL: server.baseURL,
+            publicKey: testPublicKey,
+            delegate: recorder
+        )
+        let request = URLRequest(url: URL(string: "\(server.baseURL)/v1/models")!)
+        let task = session.dataTask(with: request) { data, response, error in
+            recorder.recordCompletion(data: data, response: response, error: error)
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { task.resume() }
+            group.addTask { task.cancel() }
+        }
+
+        await fulfillment(of: [completionCalled], timeout: 2)
+        try await Task.sleep(nanoseconds: cancellationObservationDelayNanoseconds)
+
+        XCTAssertNil(recorder.completionData)
+        XCTAssertNil(recorder.completionResponse)
+        XCTAssertEqual((recorder.completionError as? URLError)?.code, .cancelled)
+        XCTAssertEqual(recorder.completionCount, 1)
+        XCTAssertEqual(recorder.delegateCompletionCount, 1)
     }
 
     // MARK: - Protocol Constants Tests
@@ -1874,6 +1905,7 @@ private final class CancellationRecorder: URLSessionDataDelegateProtocol, @unche
     private var _completionResponse: URLResponse?
     private var _completionError: Error?
     private var _completionCount = 0
+    private var _delegateCompletionCount = 0
 
     var receivedData: Data {
         lock.lock()
@@ -1905,6 +1937,12 @@ private final class CancellationRecorder: URLSessionDataDelegateProtocol, @unche
         return _completionCount
     }
 
+    var delegateCompletionCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _delegateCompletionCount
+    }
+
     init(completionCalled: XCTestExpectation) {
         self.completionCalled = completionCalled
     }
@@ -1922,7 +1960,11 @@ private final class CancellationRecorder: URLSessionDataDelegateProtocol, @unche
         }
     }
 
-    func urlSession(_ session: URLSessionProtocol, task: URLSessionTaskProtocol, didCompleteWithError error: Error?) {}
+    func urlSession(_ session: URLSessionProtocol, task: URLSessionTaskProtocol, didCompleteWithError error: Error?) {
+        lock.lock()
+        _delegateCompletionCount += 1
+        lock.unlock()
+    }
 
     func urlSession(
         _ session: URLSession,


### PR DESCRIPTION
## Summary
- synchronize stream task creation and cancellation so cancellation cannot miss a newly started request
- guarantee exactly-once completion with URLSession-compatible cancellation errors
- prevent canceled tasks from returning partial data or starting after pre-resume cancellation

## Testing
- `swift test --filter testStreamingTaskCancelledBeforeResumeNeverStartsRequest`
- `swift test --filter testStreamingCancellationDoesNotReturnPartialData`
- `swift test --filter testConcurrentStreamingResumeAndCancelCompletesOnce`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes streaming cancellation race-safe and delivers early cancellation consistently. Synchronizes start, cancel, and completion to avoid missed cancels, partial data, and mismatched errors; cancellation now returns `URLError(.cancelled)`.

- Synchronizes `resume`, `cancel`, and completion with a lock and `isCancellationRequested/hasCompleted` flags; centralizes completion in `finish(...)` to guarantee exactly-once completion and session cleanup.
- Cancel before `resume` completes immediately with `URLError(.cancelled)`, never starts the request, and triggers both the completion handler and delegate once.
- Cancel during streaming returns no data or response and completes once (handler + delegate).
- Tests cover pre-resume cancel with no request started, no partial data on cancel, and concurrent resume/cancel races; assert single delegate completion.
- Migration: If you matched `CancellationError`, update to check `(error as? URLError)?.code == .cancelled`.

<sup>Written for commit 4f98ba4281e56cf2428ba094237be5a691ba89ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

