### PR TITLE
chore: update verifier to v0.15.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Tinfoil",
-            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.15.0/Tinfoil.xcframework.zip",
-            checksum: "d81c330f899a42451b8577f9f973d986d64f59996118beff29bf1d26d5de949b"),
+            url: "https://github.com/tinfoilsh/tinfoil-go/releases/download/v0.15.4/Tinfoil.xcframework.zip",
+            checksum: "986620a216df2b5740a2cbefc9d476573914807f6129d87b14010fd9caf02749"),
         .target(
             name: "TinfoilAI",
             dependencies: [


### PR DESCRIPTION
## Summary
- update the Tinfoil XCFramework from tinfoil-go v0.15.0 to v0.15.4
- use the checksum produced by the official update_verifier.sh workflow
- remove generated Sigstore and Util headers that conflict with current Apple SDK nullability

## Testing
- `swift test`: 104 tests, 6 integration tests skipped without API key
- Tinfoil framework imports successfully on macOS
- generated Sigstore.objc.h and Util.objc.h are absent

## Source
- tinfoil-go release: https://github.com/tinfoilsh/tinfoil-go/releases/tag/v0.15.4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `Tinfoil` binary target from v0.15.0 to v0.15.4 and refreshes its checksum to match the official build, ensuring consumers get the latest verifier fixes.

- Updates `Package.swift` binary target URL to v0.15.4 and replaces the checksum with the one from the official workflow.
- No code or API changes in this repo; SwiftPM will fetch the new XCFramework on next resolve.
- No migration required.

<sup>Written for commit d10b783421ccf1f03f84ff4e670f8d9fd9c97e95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-swift/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

